### PR TITLE
Change Slippy Map MAX_ZOOM to 21.

### DIFF
--- a/src/WEDMap/WED_SlippyMap.cpp
+++ b/src/WEDMap/WED_SlippyMap.cpp
@@ -54,7 +54,7 @@
 #define SHOW_DEBUG_INFO 0
 
 #define MIN_ZOOM  13        // stop displaying OSM at all below this level
-#define MAX_ZOOM  17        // for custom mode maps (predefined maps have their own limits below)
+#define MAX_ZOOM  21        // for custom mode maps (predefined maps have their own limits below)
 
 #define TILE_FACTOR 0.8     // save tiles by zooming in a bit later than at 1:1 pixel ratio.
 							// Since zoom goes by 1.2x steps - it matters little w.r.t "sharpness"


### PR DESCRIPTION
I want to be able to use high resolution imagery when using a custom slippy map. I found that the provider I was using could provide down to z23. The WED map window only allows the user to zoom to z21. The MAX_ZOOM should be updated to match for custom providers offering high resolution data. Also could make it user customization in the preferences pane.