### PR TITLE
Remove gateway.crt from WED.rc.

### DIFF
--- a/src/WEDResources/WED.rc
+++ b/src/WEDResources/WED.rc
@@ -17,7 +17,6 @@ scrollbar_corner.png	GUI_RES		scrollbar_corner.png
 
 /* app UI elements */
 about.png				GUI_RES		about.png
-gateway.crt				GUI_RES		gateway.crt
 COPYING					GUI_RES		COPYING
 colors.png				GUI_RES		colors.png
 map_tools.png			GUI_RES		map_tools.png


### PR DESCRIPTION
The file was deleted here:

https://github.com/X-Plane/xptools/commit/fdd8ad1547e608f952e121648c9a72181b72204c

and it appears it is no longer used, but it seems it was forgotten to
delete it from WED.rc.