### PR TITLE
initialize the value of orthophotos when importing DSF

### DIFF
--- a/src/WEDImportExport/WED_DSFImport.cpp
+++ b/src/WEDImportExport/WED_DSFImport.cpp
@@ -1123,6 +1123,15 @@ public:
 			for(auto w : wdgs)
 				w->SetParent(me->poly,1);
 		}
+
+		WED_DrapedOrthophoto* orth = SAFE_CAST(WED_DrapedOrthophoto, me->poly);
+		if (orth)
+		{
+			Bbox2 textureBox;
+			orth->GetBounds(gis_UV, textureBox);
+			orth->SetSubTexture(textureBox);
+		}
+
 		me->poly = NULL;
 	}
 


### PR DESCRIPTION
For version 2.6.0 at least, when the wed project is generated from a DSF file, the value of sub texture coordinates for orthophotos are all zeros in the Editor. However when editing the texture the box is displayed correctly. Hence this is just the values not being sync to the  WED_DrapedOrthophoto object upon initialization.