### PR TITLE
Fix/gui fitforward crash

### DIFF
--- a/src/GUI/GUI_Fonts.cpp
+++ b/src/GUI/GUI_Fonts.cpp
@@ -428,6 +428,25 @@ int GUI_FitForward(int inFontID, const char* inStart, const char* inEnd,float wi
 	return (const char *) p - inStart;
 }
 
+
+int GUI_FitForward(int inFontID, std::string::const_iterator inStart, std::string::const_iterator inEnd, float width)
+{
+	if (inStart == inEnd) return 0;
+	TT_establish_font(inFontID);
+	float so_far = 0.0;
+	auto p = inStart;
+	auto e = inEnd;
+	while (p < e)
+	{
+		UTF32 c = UTF8_decode(reinterpret_cast<const UTF8*>(&*p));
+		so_far += tt_font[inFontID]->require_char(c, 1.0f);
+		if (so_far > width)
+			break;
+		p = std::next(p); // Move to next character
+	}
+	return std::distance(inStart, p);
+}
+
 int GUI_FitReverse(int inFontID, const char* inStart, const char* inEnd,float width)
 {
 	if(inStart == inEnd) return 0;
@@ -476,7 +495,8 @@ void	GUI_TruncateText(
 {
 	if (ioText.empty()) return;
 
-	int chars = GUI_FitForward(inFontID, &*ioText.begin(), &*ioText.end(), inSpace);
+	//int chars = GUI_FitForward(inFontID, &*ioText.begin(), &*ioText.end(), inSpace);
+	int chars = GUI_FitForward(inFontID, ioText.begin(), ioText.end(), inSpace);
 	if (chars == ioText.length()) return;
 	if (chars < 0) { ioText.clear(); return; }
 	if (chars > 2)

--- a/src/GUI/GUI_Fonts.cpp
+++ b/src/GUI/GUI_Fonts.cpp
@@ -477,7 +477,6 @@ void	GUI_TruncateText(
 {
 	if (ioText.empty()) return;
 
-	//int chars = GUI_FitForward(inFontID, &*ioText.begin(), &*ioText.end(), inSpace);
 	int chars = GUI_FitForward(inFontID, ioText.begin(), ioText.end(), inSpace);
 	if (chars == ioText.length()) return;
 	if (chars < 0) { ioText.clear(); return; }

--- a/src/GUI/GUI_Fonts.cpp
+++ b/src/GUI/GUI_Fonts.cpp
@@ -428,25 +428,6 @@ int GUI_FitForward(int inFontID, const char* inStart, const char* inEnd,float wi
 	return (const char *) p - inStart;
 }
 
-
-int GUI_FitForward(int inFontID, std::string::const_iterator inStart, std::string::const_iterator inEnd, float width)
-{
-	if (inStart == inEnd) return 0;
-	TT_establish_font(inFontID);
-	float so_far = 0.0;
-	auto p = inStart;
-	auto e = inEnd;
-	while (p < e)
-	{
-		UTF32 c = UTF8_decode(reinterpret_cast<const UTF8*>(&*p));
-		so_far += tt_font[inFontID]->require_char(c, 1.0f);
-		if (so_far > width)
-			break;
-		p = std::next(p); // Move to next character
-	}
-	return std::distance(inStart, p);
-}
-
 int GUI_FitReverse(int inFontID, const char* inStart, const char* inEnd,float width)
 {
 	if(inStart == inEnd) return 0;
@@ -489,9 +470,10 @@ float	GUI_GetLineAscent(int inFontID)
 }
 
 void	GUI_TruncateText(
-				string&							ioText,
-				int								inFontID,
-				float							inSpace)
+			string& ioText,
+			int								inFontID,
+			float							inSpace
+		)
 {
 	if (ioText.empty()) return;
 
@@ -503,9 +485,9 @@ void	GUI_TruncateText(
 		ioText.erase(chars + 1);   // dont cut too much, three dots are narrower than two letters
 	else
 		ioText.erase(chars);
-	if (ioText.length() > 0)	ioText[ioText.length()-1] = '.';
-	if (ioText.length() > 1)	ioText[ioText.length()-2] = '.';
-	if (ioText.length() > 2)	ioText[ioText.length()-3] = '.';
+	if (ioText.length() > 0)	ioText[ioText.length() - 1] = '.';
+	if (ioText.length() > 1)	ioText[ioText.length() - 2] = '.';
+	if (ioText.length() > 2)	ioText[ioText.length() - 3] = '.';
 
 }
 

--- a/src/GUI/GUI_Fonts.h
+++ b/src/GUI/GUI_Fonts.h
@@ -62,6 +62,7 @@ float	GUI_MeasureRange(
 				int 							inFontID,
 				const char *					inCharStart,
 				const char *					inCharEnd);
+
 int		GUI_FitForward(
 				int 							inFontID,
 				const char *					inCharStart,
@@ -69,10 +70,10 @@ int		GUI_FitForward(
 				float							inSpace);
 
 int		GUI_FitForward(
-						int inFontID,
-						std::string::const_iterator inStart,
-						std::string::const_iterator inEnd,
-						float width
+				int								inFontID,
+				std::string::const_iterator		inStart,
+				std::string::const_iterator		inEnd,
+				float							width
 					);
 
 int		GUI_FitReverse(

--- a/src/GUI/GUI_Fonts.h
+++ b/src/GUI/GUI_Fonts.h
@@ -68,6 +68,13 @@ int		GUI_FitForward(
 				const char *					inCharEnd,
 				float							inSpace);
 
+int		GUI_FitForward(
+						int inFontID,
+						std::string::const_iterator inStart,
+						std::string::const_iterator inEnd,
+						float width
+					);
+
 int		GUI_FitReverse(
 				int 							inFontID,
 				const char *					inCharStart,

--- a/src/GUI/GUI_Fonts.h
+++ b/src/GUI/GUI_Fonts.h
@@ -62,7 +62,6 @@ float	GUI_MeasureRange(
 				int 							inFontID,
 				const char *					inCharStart,
 				const char *					inCharEnd);
-
 int		GUI_FitForward(
 				int 							inFontID,
 				const char *					inCharStart,
@@ -74,7 +73,7 @@ int		GUI_FitForward(
 				std::string::const_iterator		inStart,
 				std::string::const_iterator		inEnd,
 				float							width
-					);
+);
 
 int		GUI_FitReverse(
 				int 							inFontID,


### PR DESCRIPTION
This PR fixes a startup crash in WED on Linux and Windows caused by undefined behavior in `GUI_FitForward`, where `&*ioText.end()` was used (dereferencing `end()` is invalid).

Changes:
- Overloaded `GUI_FitForward` to safely accept iterators (or switched to using `data()` and `size()`)
- Updated `GUI_TruncateText` to call the safe version

This ensures `master` is stable before working on `wed_add_edges`.

Fixes crash reported in email thread with Marco Auer on Nov 25–26, 2025.