### PR TITLE
Proper fix for GUI_FitForward callsite using UB

### DIFF
--- a/src/GUI/GUI_Fonts.cpp
+++ b/src/GUI/GUI_Fonts.cpp
@@ -477,7 +477,7 @@ void	GUI_TruncateText(
 {
 	if (ioText.empty()) return;
 
-	int chars = GUI_FitForward(inFontID, ioText.begin(), ioText.end(), inSpace);
+	int chars = GUI_FitForward(inFontID, ioText.data(), ioText.data() + ioText.size(), inSpace);
 	if (chars == ioText.length()) return;
 	if (chars < 0) { ioText.clear(); return; }
 	if (chars > 2)

--- a/src/GUI/GUI_Fonts.h
+++ b/src/GUI/GUI_Fonts.h
@@ -68,13 +68,6 @@ int		GUI_FitForward(
 				const char *					inCharEnd,
 				float							inSpace);
 
-int		GUI_FitForward(
-				int								inFontID,
-				std::string::const_iterator		inStart,
-				std::string::const_iterator		inEnd,
-				float							width
-);
-
 int		GUI_FitReverse(
 				int 							inFontID,
 				const char *					inCharStart,


### PR DESCRIPTION
Use pointer arithmatic instead of iterators. This is still ugly code, but at least it is now valid C++ and, not unimportantly... it actually compiles, as opposed to Ilyass' fix in https://github.com/X-Plane/xptools/pull/39