### PR TITLE
Fix/dsf2text object def over 255

### DIFF
--- a/src/DSF/DSFLib.cpp
+++ b/src/DSF/DSFLib.cpp
@@ -289,7 +289,9 @@ static set<int> GetAllPools(XAtomPackedData& cmdsAtom, bool overlay)
 			currentPool = cmdsAtom.ReadUInt16();
 			break;
 		case dsf_Cmd_ObjectRange:
-			if (!overlay) ptPools.insert(currentPool);
+			if (!overlay && currentPool != 0xFFFF) ptPools.insert(currentPool);
+			cmdsAtom.Advance(4);
+			break;
 		case dsf_Cmd_NetworkChainRange:
 		case dsf_Cmd_JunctionOffsetSelect:
 		case dsf_Cmd_SetDefinition32:
@@ -300,9 +302,11 @@ static set<int> GetAllPools(XAtomPackedData& cmdsAtom, bool overlay)
 			cmdsAtom.Advance(1);
 			break;
 		case dsf_Cmd_SetDefinition16:
+			cmdsAtom.Advance(2);
+			break;
 		case dsf_Cmd_Object:
 			cmdsAtom.Advance(2);
-			if (!overlay) ptPools.insert(currentPool);
+			if (!overlay && currentPool != 0xFFFF) ptPools.insert(currentPool);
 			break;
 		case dsf_Cmd_NetworkChain:
 			count = cmdsAtom.ReadUInt8();

--- a/src/DSF/DSFPointPool.cpp
+++ b/src/DSF/DSFPointPool.cpp
@@ -29,6 +29,11 @@
 #if USE_PVRTC
 #include "PVRTTriStrip.h"
 #else
+// The tri_stripper headers pull in <fstream>; keep XDefs' fopen shim out of
+// that include path so libc++ can resolve std::fopen normally.
+#ifdef fopen
+#undef fopen
+#endif
 #include "stdafx.h"
 #include "tri_stripper.h"
 using namespace	triangle_stripper;
@@ -765,4 +770,3 @@ void DSFOptimizePrimitives(
 #endif
 	swap(io_primitives,out_prims);
 }
-

--- a/src/DSF/DSFPointPool.cpp
+++ b/src/DSF/DSFPointPool.cpp
@@ -765,3 +765,4 @@ void DSFOptimizePrimitives(
 #endif
 	swap(io_primitives,out_prims);
 }
+

--- a/src/DSF/DSFPointPool.cpp
+++ b/src/DSF/DSFPointPool.cpp
@@ -29,11 +29,6 @@
 #if USE_PVRTC
 #include "PVRTTriStrip.h"
 #else
-// The tri_stripper headers pull in <fstream>; keep XDefs' fopen shim out of
-// that include path so libc++ can resolve std::fopen normally.
-#ifdef fopen
-#undef fopen
-#endif
 #include "stdafx.h"
 #include "tri_stripper.h"
 using namespace	triangle_stripper;


### PR DESCRIPTION
## Summary

Fix a `DSFTool --dsf2text` crash that occurs when a DSF contains `OBJECT` / `OBJECT_MSL` placements whose definition index is >= 256.

## Root cause

The crash is caused in `GetAllPools()` in `src/DSF/DSFLib.cpp`.

`dsf_Cmd_SetDefinition16` was handled in the same switch arm as `dsf_Cmd_Object`, so the code advanced past the 16-bit definition command and also inserted `currentPool` into the pool set as if an object placement had been seen.

If no valid `PoolSelect` had been processed yet, this inserted the sentinel pool value `0xFFFF`. Later, point-pool info generation dereferenced that invalid pool, which causes the crash.

This starts to happen exactly when object definition indices cross from 8-bit to 16-bit encoding, i.e. at index 256.

## Fix

- handle `dsf_Cmd_SetDefinition16` separately
- only insert pools for actual `dsf_Cmd_Object` / `dsf_Cmd_ObjectRange` commands
- guard object pool insertion against the sentinel value `0xFFFF`

## Verification

Reproduced before the fix with minimal synthetic DSFs:
- `OBJECT` index 255: OK
- `OBJECT` index 256: crash
- same threshold for `OBJECT_MSL`

Verified after the fix:
- minimal `OBJECT 256` case decodes correctly
- minimal `OBJECT_MSL 256` case decodes correctly
- real-world CYYZ DSF decodes correctly
- full `text2dsf -> dsf2text` roundtrip on CYYZ also succeeds
