### PR TITLE
Disable pointer optimizations

### DIFF
--- a/src/WEDCore/WED_PropertyHelper.h
+++ b/src/WEDCore/WED_PropertyHelper.h
@@ -78,14 +78,14 @@ class	WED_XMLElement;
    pointing from each property back to the WED_Thing a full pointer and not just an 8 bit relative pointer.
 
    Using some more clever vector like LLVM's SmallVector or boosts small_vector would eliminate the
-   need for a fixed array here. In that case - an inline size of 16 elements would suffice to hold 
-   the relaive offsets for all entities except runways - only those have more properties. So that saves 
+   need for a fixed array here. In that case - an inline size of 16 elements would suffice to hold
+   the relaive offsets for all entities except runways - only those have more properties. So that saves
    even more memory and reduced any need in the future to re-adjust this fixed array for increased couunts !
    There are a LOT less runways than vertices and other entities - so loosing some optimizations for that
    entity type is not causing any notable drawbacks.
 */
 
-#define PROP_PTR_OPT 32
+#define PROP_PTR_OPT 0
 
 class	WED_PropertyItem {
 public:


### PR DESCRIPTION
On some systems and with enabled optimizations, the code runs into segfaults at

`__strcmp_evex () at ../sysdeps/x86_64/multiarch/strcmp-evex.S:316`

in

`bool WED_PropStringText::WantsAttribute(..)`

at

`src/WEDCore/WED_PropertyHelper.cpp:580`

Until this is properly fixed, the suggestion is to switch them off to allow WED to load airports again.

---

Partial stacktrace of `build_Debug` in gdb:

```txt
Thread 1 "WED" received signal SIGSEGV, Segmentation fault.
__strcmp_evex () at ../sysdeps/x86_64/multiarch/strcmp-evex.S:316
316             VMOVU   (%rdi), %VMM(0)
(gdb) bt
#0  __strcmp_evex () at ../sysdeps/x86_64/multiarch/strcmp-evex.S:316
#1  0x0000555555dd83d6 in WED_PropStringText::WantsAttribute (this=0x555558d70360, ele=0x555558d6fe7c "hierarchy", att_name=0x555558d6f61f "name", att_value=0x555558d6fe86 "Facade 5 outer ring") at /home/menax/Projects/forks/xptools/src/WEDCore/WED_PropertyHelper.cpp:580
#2  0x0000555555dd6fbb in WED_PropertyHelper::StartElement (this=0x555558d702b0, reader=0x7fffffffbcb0, name=0x555558d6fe7c "hierarchy", atts=0x555558d6d3b0) at /home/menax/Projects/forks/xptools/src/WEDCore/WED_PropertyHelper.cpp:193
#3  0x0000555555f37690 in WED_Thing::StartElement (this=0x555558d70290, reader=0x7fffffffbcb0, name=0x555558d6fe7c "hierarchy", atts=0x555558d6d3a0) at /home/menax/Projects/forks/xptools/src/WEDEntities/WED_Thing.cpp:209
#4  0x0000555555ec16ca in WED_XMLReader::StartElementHandler (userData=0x7fffffffbcb0, name=0x555558d6fe7c "hierarchy", atts=0x555558d6d3a0) at /home/menax/Projects/forks/xptools/src/WEDCore/WED_XMLReader.cpp:90
[...]
```