### PR TITLE
Block mouse release event while in drag/drop

### DIFF
--- a/src/GUI/GUI_Window.cpp
+++ b/src/GUI/GUI_Window.cpp
@@ -696,7 +696,9 @@ void			GUI_Window::ClickDown(int inX, int inY, int inButton)
 {
 	DebugAssert(mMouseFocusPane[inButton] == NULL);
 	this->GetRootForCommander()->BeginDefer();
+	mBlockMouseReleaseEvent = 1;
 	mMouseFocusPane[inButton] = InternalMouseDown(Client2OGL_X(inX, mWindow), Client2OGL_Y(inY, mWindow), inButton);
+	mBlockMouseReleaseEvent = 0;
 
 //		Ben says - we should not need to poll on mouse clickig...turn off for now
 //					until we find out what the hell needed this!

--- a/src/UI/XWin.h
+++ b/src/UI/XWin.h
@@ -272,6 +272,7 @@ protected:
 	int		mDragging; // Button being dragged or -1 if none ;
 	int		mWantFakeUp;
 	int		mBlockEvents;
+	int     mBlockMouseReleaseEvent;
     double	mTimer;
 	POINT	mMouse;
 	bool	mUpdateCallbackActive;

--- a/src/UI/XWin.lin.cpp
+++ b/src/UI/XWin.lin.cpp
@@ -77,6 +77,7 @@ XWin::XWin(
 	mDragging    =-1;
 	mWantFakeUp  = 0;
 	mBlockEvents = 0;
+	mBlockMouseReleaseEvent = 0;
 	mMouse.x     = 0;
 	mMouse.y     = 0;
 	mTimer=0;
@@ -105,6 +106,7 @@ XWin::XWin(int default_dnd) : Fl_Window(100,100),
 	mDragging    =-1;
 	mWantFakeUp  = 0;
 	mBlockEvents = 0;
+	mBlockMouseReleaseEvent = 0;
 	mMouse.x     = 0;
 	mMouse.y     = 0;
 	mTimer=0;
@@ -226,7 +228,7 @@ int XWin::handle(int e)
 		mMouse.x = Fl::event_x();
 		mMouse.y = Fl::event_y();
 
-		if(mBlockEvents) return 1;
+		if(mBlockEvents || mBlockMouseReleaseEvent) return 1;
 
 		if(mDragging == btn)
 		{


### PR DESCRIPTION
When doing a drag-and-drop operation on the hierarchy pane, `GUI_Window.cpp::ClickDown` (FL_PUSH) leads to `GUI_Pane::InternalMouseDown`, which blocks there until mouse button release. Upon button release the FL_RELEASE event is handled while the FL_PUSH event is still not fully consumed. The variable/flag assignments on `mDragging`, `mWantFakeUp` and `btn` finally lead to `btn` holding a -1 value, which is passed to `GUI_Window.cpp::ClickUp`. There, the code passes the if-guard but then crashes due to inaccessible memory when doing

`mMouseFocusPane[inButton]->MouseUp(..)`

Example debug tracing:

```txt
GUI_Window.cpp::ClickUp
  this=0x55de166b3660
  name=18WED_DocumentWindow
  inButton=-1
  mMouseFocusPane[inButton]=0xc00001003f800000  <-- invalid
```