### PR TITLE
Add bounded artifact cache hot paths for large-airport open

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ find_package(CURL REQUIRED)
 find_package(opengl_system REQUIRED)
 find_package(glew REQUIRED)
 find_package(jsoncpp REQUIRED)
+find_package(SQLite3 REQUIRED)
+find_path(WED_SQLITE3_INCLUDE_DIR sqlite3.h REQUIRED)
 
 if (APPLE)
 	find_library(CARBON_FRAMEWORK Carbon REQUIRED)

--- a/cmake/WED.cmake
+++ b/cmake/WED.cmake
@@ -71,6 +71,8 @@ set (WED_SOURCES
 	src/WEDCore/WED_Assert.h
 	src/WEDCore/WED_ResourceMgr.cpp
 	src/WEDCore/WED_ResourceMgr.h
+	src/WEDCore/WED_ResourceCache.cpp
+	src/WEDCore/WED_ResourceCache.h
 	src/WEDCore/WED_Sign_Parser.cpp
 	src/WEDCore/WED_Sign_Parser.h
 	src/WEDCore/WED_GISUtils.cpp
@@ -760,6 +762,7 @@ target_include_directories(WED PRIVATE
 	src/Tiger
 	src/SDTS
 	src/linuxinit
+	${WED_SQLITE3_INCLUDE_DIR}
 )
 
 target_link_libraries(WED PRIVATE
@@ -776,6 +779,7 @@ target_link_libraries(WED PRIVATE
 	opengl::opengl
 	GLEW::glew_s
 	JsonCpp::JsonCpp
+	SQLite::SQLite3
 )
 
 if (WIN32)

--- a/src/Utils/TexUtils.cpp
+++ b/src/Utils/TexUtils.cpp
@@ -23,6 +23,10 @@
 #include "TexUtils.h"
 #include "AssertUtils.h"
 #include "BitmapUtils.h"
+#include <cctype>
+#include <chrono>
+#include <cstdlib>
+#include <string>
 #include <vector>
 
 #if APL
@@ -51,6 +55,19 @@ struct  gl_info_t {
 };
 
 static gl_info_t gl_info = { 0 };
+
+static bool EnvFlagEnabled(const char * name)
+{
+	const char * raw = getenv(name);
+	if (raw == nullptr || raw[0] == '\0')
+		return false;
+
+	std::string lowered(raw);
+	for (char& ch : lowered)
+		ch = static_cast<char>(tolower(static_cast<unsigned char>(ch)));
+
+	return lowered != "0" && lowered != "false" && lowered != "off" && lowered != "no";
+}
 
 #define INIT_GL_INFO		if(gl_info.gl_major_version == 0) init_gl_info(&gl_info);
 
@@ -164,6 +181,26 @@ void DestroyPreparedTextureImage(PreparedTextureImage * image)
 	image->vis_y = 0;
 }
 
+void DestroyCompressedTextureImage(CompressedTextureImage * image)
+{
+	if (image == nullptr)
+		return;
+	free(image->data);
+	image->data = nullptr;
+	image->data_size = 0;
+	image->internal_format = 0;
+	image->width = 0;
+	image->height = 0;
+	image->level_count = 0;
+	image->org_x = 0;
+	image->org_y = 0;
+	image->act_x = 0;
+	image->act_y = 0;
+	image->vis_x = 0;
+	image->vis_y = 0;
+	image->level_sizes.clear();
+}
+
 /*****************************************************************************************
  * UTILS
  *****************************************************************************************/
@@ -264,11 +301,26 @@ bool PrepareTextureImageForUpload(ImageInfo& im, int inFlags, PreparedTextureIma
 	return outPrepared->data != nullptr;
 }
 
-bool LoadTextureFromPreparedImage(const PreparedTextureImage& prepared, int inTexNum, int inFlags)
+bool LoadTextureFromPreparedImage(const PreparedTextureImage& prepared, int inTexNum, int inFlags, PreparedTextureUploadPerf * outPerf)
 {
 	EnsureTextureUploadCapsInitializedOnDrawThread();
 	if (prepared.data == nullptr || prepared.width <= 0 || prepared.height <= 0 || prepared.channels <= 0)
 		return false;
+
+	const int effective_flags = EnvFlagEnabled("WED_PERF_DISABLE_TEX_COMPRESS_OK") ? (inFlags & ~tex_Compress_Ok) : inFlags;
+
+	if (outPerf != nullptr)
+	{
+		*outPerf = PreparedTextureUploadPerf();
+		outPerf->data_size = prepared.data_size;
+		outPerf->width = prepared.width;
+		outPerf->height = prepared.height;
+		outPerf->channels = prepared.channels;
+		outPerf->level_count = prepared.level_count;
+		outPerf->compress_ok = (effective_flags & tex_Compress_Ok) ? 1 : 0;
+	}
+
+	const auto total_begin = outPerf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
 
 	glBindTexture(GL_TEXTURE_2D, inTexNum);  CHECK_GL_ERR
 
@@ -295,7 +347,7 @@ bool LoadTextureFromPreparedImage(const PreparedTextureImage& prepared, int inTe
 			iformat = glformat = GL_RGBA;
 	}
 
-	if (gl_info.has_tex_compression && (inFlags & tex_Compress_Ok))
+	if (gl_info.has_tex_compression && (effective_flags & tex_Compress_Ok))
 	{
 		switch (iformat) {
 		case GL_RGB:	iformat = GL_COMPRESSED_RGB;	break;
@@ -307,15 +359,19 @@ bool LoadTextureFromPreparedImage(const PreparedTextureImage& prepared, int inTe
 	const unsigned char * upload_data = prepared.data;
 	if (!gl_info.has_bgra && prepared.channels >= 3)
 	{
+		const auto convert_begin = outPerf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
 		converted.assign(prepared.data, prepared.data + prepared.data_size);
 		for (int offset = 0; offset < prepared.data_size; offset += prepared.channels)
 			swap(converted[offset + 0], converted[offset + 2]);
 		upload_data = converted.data();
+		if (outPerf != nullptr)
+			outPerf->convert_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - convert_begin).count();
 	}
 
 	int level_width = prepared.width;
 	int level_height = prepared.height;
 	int byte_offset = 0;
+	const auto upload_begin = outPerf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
 	for (int level = 0; level < prepared.level_count; ++level)
 	{
 		const int level_size = level_width * level_height * prepared.channels;
@@ -326,8 +382,150 @@ bool LoadTextureFromPreparedImage(const PreparedTextureImage& prepared, int inTe
 		if (level_width > 1) level_width >>= 1;
 		if (level_height > 1) level_height >>= 1;
 	}
+	if (outPerf != nullptr)
+		outPerf->upload_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - upload_begin).count();
 
-	ConfigureTextureSampling(inFlags);
+	const auto configure_begin = outPerf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+	ConfigureTextureSampling(effective_flags);
+	if (outPerf != nullptr)
+	{
+		outPerf->configure_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - configure_begin).count();
+		outPerf->total_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - total_begin).count();
+	}
+	return true;
+}
+
+bool CaptureCompressedTextureFromBoundTexture(const PreparedTextureImage& prepared, CompressedTextureImage * outCompressed)
+{
+	EnsureTextureUploadCapsInitializedOnDrawThread();
+	if (outCompressed == nullptr || !gl_info.has_tex_compression)
+		return false;
+
+	DestroyCompressedTextureImage(outCompressed);
+
+	GLint level_zero_compressed = GL_FALSE;
+	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_COMPRESSED, &level_zero_compressed); CHECK_GL_ERR
+	if (level_zero_compressed != GL_TRUE)
+		return false;
+
+	GLint internal_format = 0;
+	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &internal_format); CHECK_GL_ERR
+	if (internal_format == 0)
+		return false;
+
+	outCompressed->internal_format = internal_format;
+	outCompressed->width = prepared.width;
+	outCompressed->height = prepared.height;
+	outCompressed->level_count = prepared.level_count;
+	outCompressed->org_x = prepared.org_x;
+	outCompressed->org_y = prepared.org_y;
+	outCompressed->act_x = prepared.act_x;
+	outCompressed->act_y = prepared.act_y;
+	outCompressed->vis_x = prepared.vis_x;
+	outCompressed->vis_y = prepared.vis_y;
+	outCompressed->level_sizes.reserve(prepared.level_count);
+
+	int total_size = 0;
+	int level_width = prepared.width;
+	int level_height = prepared.height;
+	for (int level = 0; level < prepared.level_count; ++level)
+	{
+		GLint level_compressed = GL_FALSE;
+		GLint level_size = 0;
+		glGetTexLevelParameteriv(GL_TEXTURE_2D, level, GL_TEXTURE_COMPRESSED, &level_compressed); CHECK_GL_ERR
+		glGetTexLevelParameteriv(GL_TEXTURE_2D, level, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, &level_size); CHECK_GL_ERR
+		if (level_compressed != GL_TRUE || level_size <= 0)
+		{
+			DestroyCompressedTextureImage(outCompressed);
+			return false;
+		}
+		outCompressed->level_sizes.push_back(level_size);
+		total_size += level_size;
+		if (level_width == 1 && level_height == 1)
+			break;
+		if (level_width > 1) level_width >>= 1;
+		if (level_height > 1) level_height >>= 1;
+	}
+
+	outCompressed->level_count = static_cast<int>(outCompressed->level_sizes.size());
+	outCompressed->data_size = total_size;
+	if (total_size <= 0)
+	{
+		DestroyCompressedTextureImage(outCompressed);
+		return false;
+	}
+
+	outCompressed->data = reinterpret_cast<unsigned char *>(malloc(static_cast<size_t>(total_size)));
+	if (outCompressed->data == nullptr)
+	{
+		DestroyCompressedTextureImage(outCompressed);
+		return false;
+	}
+
+	int byte_offset = 0;
+	for (int level = 0; level < outCompressed->level_count; ++level)
+	{
+		glGetCompressedTexImage(GL_TEXTURE_2D, level, outCompressed->data + byte_offset); CHECK_GL_ERR
+		byte_offset += outCompressed->level_sizes[level];
+	}
+
+	return true;
+}
+
+bool LoadTextureFromCompressedImage(const CompressedTextureImage& compressed, int inTexNum, int inFlags, PreparedTextureUploadPerf * outPerf)
+{
+	EnsureTextureUploadCapsInitializedOnDrawThread();
+	if (compressed.data == nullptr ||
+		compressed.data_size <= 0 ||
+		compressed.internal_format == 0 ||
+		compressed.width <= 0 ||
+		compressed.height <= 0 ||
+		compressed.level_count <= 0 ||
+		static_cast<int>(compressed.level_sizes.size()) != compressed.level_count)
+		return false;
+
+	const int effective_flags = EnvFlagEnabled("WED_PERF_DISABLE_TEX_COMPRESS_OK") ? (inFlags & ~tex_Compress_Ok) : inFlags;
+
+	if (outPerf != nullptr)
+	{
+		*outPerf = PreparedTextureUploadPerf();
+		outPerf->data_size = compressed.data_size;
+		outPerf->width = compressed.width;
+		outPerf->height = compressed.height;
+		outPerf->channels = 0;
+		outPerf->level_count = compressed.level_count;
+		outPerf->compress_ok = 1;
+	}
+
+	const auto total_begin = outPerf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+
+	glBindTexture(GL_TEXTURE_2D, inTexNum); CHECK_GL_ERR
+
+	int byte_offset = 0;
+	int level_width = compressed.width;
+	int level_height = compressed.height;
+	const auto upload_begin = outPerf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+	for (int level = 0; level < compressed.level_count; ++level)
+	{
+		const int level_size = compressed.level_sizes[level];
+		glCompressedTexImage2D(GL_TEXTURE_2D, level, compressed.internal_format, level_width, level_height, 0, level_size, compressed.data + byte_offset); CHECK_GL_ERR
+		byte_offset += level_size;
+		if (level_width == 1 && level_height == 1)
+			break;
+		if (level_width > 1) level_width >>= 1;
+		if (level_height > 1) level_height >>= 1;
+	}
+	if (outPerf != nullptr)
+		outPerf->upload_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - upload_begin).count();
+
+	const auto configure_begin = outPerf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+	ConfigureTextureSampling(effective_flags);
+	if (outPerf != nullptr)
+	{
+		outPerf->configure_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - configure_begin).count();
+		outPerf->total_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - total_begin).count();
+	}
+
 	return true;
 }
 

--- a/src/Utils/TexUtils.cpp
+++ b/src/Utils/TexUtils.cpp
@@ -23,6 +23,7 @@
 #include "TexUtils.h"
 #include "AssertUtils.h"
 #include "BitmapUtils.h"
+#include <vector>
 
 #if APL
 	#include <OpenGL/gl.h>
@@ -99,6 +100,70 @@ static void init_gl_info(gl_info_t * i)
 	LOG_FLUSH();
 }
 
+void EnsureTextureUploadCapsInitializedOnDrawThread()
+{
+	INIT_GL_INFO
+}
+
+bool TextureUploadCapsReady()
+{
+	return gl_info.gl_major_version != 0;
+}
+
+static int PreparedTextureStorageBytes(int width, int height, int channels, int level_count)
+{
+	int total = 0;
+	int level_width = width;
+	int level_height = height;
+	for (int level = 0; level < level_count; ++level)
+	{
+		total += level_width * level_height * channels;
+		if (level_width == 1 && level_height == 1)
+			break;
+		if (level_width > 1) level_width >>= 1;
+		if (level_height > 1) level_height >>= 1;
+	}
+	return total;
+}
+
+static void ConfigureTextureSampling(int inFlags)
+{
+	if (inFlags & tex_Linear) {
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, (inFlags & tex_Mipmap) ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR);
+	} else {
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, (inFlags & tex_Mipmap) ? GL_NEAREST_MIPMAP_NEAREST : GL_LINEAR);
+	}
+	if(inFlags & tex_Wrap) {
+		glTexParameteri(GL_TEXTURE_2D,GL_TEXTURE_WRAP_S,GL_REPEAT );
+		glTexParameteri(GL_TEXTURE_2D,GL_TEXTURE_WRAP_T,GL_REPEAT );
+	}
+	else {
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	}
+}
+
+void DestroyPreparedTextureImage(PreparedTextureImage * image)
+{
+	if (image == nullptr)
+		return;
+	free(image->data);
+	image->data = nullptr;
+	image->data_size = 0;
+	image->width = 0;
+	image->height = 0;
+	image->channels = 0;
+	image->level_count = 0;
+	image->org_x = 0;
+	image->org_y = 0;
+	image->act_x = 0;
+	image->act_y = 0;
+	image->vis_x = 0;
+	image->vis_y = 0;
+}
+
 /*****************************************************************************************
  * UTILS
  *****************************************************************************************/
@@ -122,6 +187,148 @@ void UnpadImage(ImageInfo * im)
 			memmove(dst,src,im->width * im->channels);
 	}
 	im->pad = 0;
+}
+
+bool PrepareTextureImageForUpload(ImageInfo& im, int inFlags, PreparedTextureImage * outPrepared)
+{
+	if (outPrepared == nullptr || !TextureUploadCapsReady())
+		return false;
+
+	DestroyPreparedTextureImage(outPrepared);
+
+	if (inFlags & tex_MagentaAlpha)	ConvertBitmapToAlpha(&im, true);
+	if (im.pad != 0)
+		UnpadImage(&im);
+
+	int non_pots = ((inFlags & tex_Always_Pad) == 0) && gl_info.has_non_pots;
+	int res_x = non_pots ? min((int) im.width, gl_info.max_tex_size) : NextPowerOf2(im.width);
+	int res_y = non_pots ? min((int) im.height, gl_info.max_tex_size) : NextPowerOf2(im.height);
+	bool resize = (res_x != im.width || res_y != im.height);
+	bool rescale = resize && (inFlags & tex_Rescale);
+	if (im.width > res_x || im.height > res_y)
+		rescale = true;
+
+	ImageInfo * useIt = &im;
+	ImageInfo rescaleBits = { 0 };
+	float out_s = 1.0f;
+	float out_t = 1.0f;
+
+	if (resize)
+	{
+		if (CreateNewBitmap(res_x, res_y, im.channels, &rescaleBits) != 0)
+			return false;
+
+		useIt = &rescaleBits;
+		if (rescale)
+		{
+			CopyBitmapSection(&im, &rescaleBits, 0, 0, im.width, im.height, 0, 0, rescaleBits.width, rescaleBits.height);
+		}
+		else
+		{
+			CopyBitmapSectionDirect(im, rescaleBits, 0, 0, 0, 0, im.width, im.height);
+			if (im.width < rescaleBits.width)
+				CopyBitmapSectionDirect(im, rescaleBits, im.width - 1, 0, im.width, 0, 1, im.height);
+			if (im.height < rescaleBits.height)
+				CopyBitmapSectionDirect(im, rescaleBits, 0, im.height - 1, 0, im.height, im.width, 1);
+			if (im.height < rescaleBits.height && im.width < rescaleBits.width)
+				CopyBitmapSectionDirect(im, rescaleBits, im.width - 1, im.height - 1, im.width, im.height, 1, 1);
+			out_s = (float) im.width / (float) rescaleBits.width;
+			out_t = (float) im.height / (float) rescaleBits.height;
+		}
+	}
+
+	outPrepared->org_x = im.width;
+	outPrepared->org_y = im.height;
+	outPrepared->act_x = useIt->width;
+	outPrepared->act_y = useIt->height;
+	outPrepared->vis_x = static_cast<int>(static_cast<float>(useIt->width) * out_s);
+	outPrepared->vis_y = static_cast<int>(static_cast<float>(useIt->height) * out_t);
+	outPrepared->width = useIt->width;
+	outPrepared->height = useIt->height;
+	outPrepared->channels = useIt->channels;
+	outPrepared->level_count = (inFlags & tex_Mipmap) ? MakeMipmapStack(useIt) : 1;
+	outPrepared->data = useIt->data;
+	outPrepared->data_size = PreparedTextureStorageBytes(outPrepared->width, outPrepared->height, outPrepared->channels, outPrepared->level_count);
+	useIt->data = nullptr;
+
+	if (resize)
+	{
+		DestroyBitmap(&im);
+		im.data = nullptr;
+		im.width = 0;
+		im.height = 0;
+		im.pad = 0;
+		im.channels = 0;
+	}
+
+	return outPrepared->data != nullptr;
+}
+
+bool LoadTextureFromPreparedImage(const PreparedTextureImage& prepared, int inTexNum, int inFlags)
+{
+	EnsureTextureUploadCapsInitializedOnDrawThread();
+	if (prepared.data == nullptr || prepared.width <= 0 || prepared.height <= 0 || prepared.channels <= 0)
+		return false;
+
+	glBindTexture(GL_TEXTURE_2D, inTexNum);  CHECK_GL_ERR
+
+	int iformat;
+	int glformat;
+	if (prepared.channels == 1)
+	{
+		iformat = glformat = GL_ALPHA;
+	}
+	else if (gl_info.has_bgra)
+	{
+		iformat = GL_RGB;
+		glformat = GL_BGR;
+		if (prepared.channels == 4)
+		{
+			iformat = GL_RGBA;
+			glformat = GL_BGRA;
+		}
+	}
+	else
+	{
+		iformat = glformat = GL_RGB;
+		if (prepared.channels == 4)
+			iformat = glformat = GL_RGBA;
+	}
+
+	if (gl_info.has_tex_compression && (inFlags & tex_Compress_Ok))
+	{
+		switch (iformat) {
+		case GL_RGB:	iformat = GL_COMPRESSED_RGB;	break;
+		case GL_RGBA:	iformat = GL_COMPRESSED_RGBA;	break;
+		}
+	}
+
+	std::vector<unsigned char> converted;
+	const unsigned char * upload_data = prepared.data;
+	if (!gl_info.has_bgra && prepared.channels >= 3)
+	{
+		converted.assign(prepared.data, prepared.data + prepared.data_size);
+		for (int offset = 0; offset < prepared.data_size; offset += prepared.channels)
+			swap(converted[offset + 0], converted[offset + 2]);
+		upload_data = converted.data();
+	}
+
+	int level_width = prepared.width;
+	int level_height = prepared.height;
+	int byte_offset = 0;
+	for (int level = 0; level < prepared.level_count; ++level)
+	{
+		const int level_size = level_width * level_height * prepared.channels;
+		glTexImage2D(GL_TEXTURE_2D, level, iformat, level_width, level_height, 0, glformat, GL_UNSIGNED_BYTE, upload_data + byte_offset); CHECK_GL_ERR
+		byte_offset += level_size;
+		if (level_width == 1 && level_height == 1)
+			break;
+		if (level_width > 1) level_width >>= 1;
+		if (level_height > 1) level_height >>= 1;
+	}
+
+	ConfigureTextureSampling(inFlags);
+	return true;
 }
 
 /*****************************************************************************************

--- a/src/Utils/TexUtils.h
+++ b/src/Utils/TexUtils.h
@@ -24,6 +24,36 @@
 #define TEXUTILS_H
 
 struct	ImageInfo;
+struct	PreparedTextureImage {
+	PreparedTextureImage() :
+		data(nullptr),
+		data_size(0),
+		width(0),
+		height(0),
+		channels(0),
+		level_count(0),
+		org_x(0),
+		org_y(0),
+		act_x(0),
+		act_y(0),
+		vis_x(0),
+		vis_y(0)
+	{
+	}
+
+	unsigned char *	data;
+	int				data_size;
+	int				width;
+	int				height;
+	int				channels;
+	int				level_count;
+	int				org_x;
+	int				org_y;
+	int				act_x;
+	int				act_y;
+	int				vis_x;
+	int				vis_y;
+};
 
 enum {
 
@@ -55,6 +85,18 @@ bool LoadTextureFromImage(
 				int * 			outHeight,
 				float *			outS,
 				float *			outT);
+
+void EnsureTextureUploadCapsInitializedOnDrawThread();
+bool TextureUploadCapsReady();
+bool PrepareTextureImageForUpload(
+				ImageInfo&					inInfo,
+				int							inFlags,
+				PreparedTextureImage *		outPrepared);
+bool LoadTextureFromPreparedImage(
+				const PreparedTextureImage&	inPrepared,
+				int							inTexNum,
+				int							inFlags);
+void DestroyPreparedTextureImage(PreparedTextureImage * image);
 
 bool LoadTextureFromDDS(
 				char *			mem_start,

--- a/src/Utils/TexUtils.h
+++ b/src/Utils/TexUtils.h
@@ -23,6 +23,8 @@
 #ifndef TEXUTILS_H
 #define TEXUTILS_H
 
+#include <vector>
+
 struct	ImageInfo;
 struct	PreparedTextureImage {
 	PreparedTextureImage() :
@@ -53,6 +55,65 @@ struct	PreparedTextureImage {
 	int				act_y;
 	int				vis_x;
 	int				vis_y;
+};
+
+struct CompressedTextureImage {
+	CompressedTextureImage() :
+		data(nullptr),
+		data_size(0),
+		internal_format(0),
+		width(0),
+		height(0),
+		level_count(0),
+		org_x(0),
+		org_y(0),
+		act_x(0),
+		act_y(0),
+		vis_x(0),
+		vis_y(0)
+	{
+	}
+
+	unsigned char *		data;
+	int					data_size;
+	int					internal_format;
+	int					width;
+	int					height;
+	int					level_count;
+	int					org_x;
+	int					org_y;
+	int					act_x;
+	int					act_y;
+	int					vis_x;
+	int					vis_y;
+	std::vector<int>	level_sizes;
+};
+
+struct PreparedTextureUploadPerf {
+	PreparedTextureUploadPerf() :
+		convert_seconds(0.0),
+		upload_seconds(0.0),
+		configure_seconds(0.0),
+		total_seconds(0.0),
+		data_size(0),
+		width(0),
+		height(0),
+		channels(0),
+		level_count(0),
+		compress_ok(0)
+	{
+	}
+
+	double			convert_seconds;
+	double			upload_seconds;
+	double			configure_seconds;
+	double			total_seconds;
+	int				data_size;
+	int				width;
+	int				height;
+	int				channels;
+	int				level_count;
+	int				compress_ok;
 };
 
 enum {
@@ -95,8 +156,18 @@ bool PrepareTextureImageForUpload(
 bool LoadTextureFromPreparedImage(
 				const PreparedTextureImage&	inPrepared,
 				int							inTexNum,
-				int							inFlags);
+				int							inFlags,
+				PreparedTextureUploadPerf *	outPerf = nullptr);
 void DestroyPreparedTextureImage(PreparedTextureImage * image);
+bool CaptureCompressedTextureFromBoundTexture(
+				const PreparedTextureImage&	inPrepared,
+				CompressedTextureImage *	outCompressed);
+bool LoadTextureFromCompressedImage(
+				const CompressedTextureImage&	inCompressed,
+				int								inTexNum,
+				int								inFlags,
+				PreparedTextureUploadPerf *		outPerf = nullptr);
+void DestroyCompressedTextureImage(CompressedTextureImage * image);
 
 bool LoadTextureFromDDS(
 				char *			mem_start,

--- a/src/WEDCore/WED_ResourceCache.cpp
+++ b/src/WEDCore/WED_ResourceCache.cpp
@@ -5,6 +5,7 @@
 #include "WED_ResourceCache.h"
 
 #include "FileUtils.h"
+#include "GUI_Prefs.h"
 #include "MemFileUtils.h"
 #include "PlatformUtils.h"
 
@@ -19,6 +20,12 @@
 #include <cstring>
 #include <sys/stat.h>
 
+#if IBM
+#include <windows.h>
+#else
+#include <sys/statvfs.h>
+#endif
+
 extern "C" {
 #include "sqlite3.h"
 }
@@ -29,8 +36,15 @@ static const int kObjMetaSchemaVersion = 1;
 static const int kObjGeomSchemaVersion = 1;
 static const int kTexPreparedSchemaVersion = 1;
 static const int kTexCompressedSchemaVersion = 1;
-static const char * kPackFileName = "artifacts.pack";
+static const int kCacheLayoutVersion = 3;
 static const unsigned int kPackMagic = 0x32524357;  // WCR2
+static const long long kSegmentSizeBytes = 1LL << 30;
+static const long long kConfiguredHardCapBytes = 16LL << 30;
+static const long long kPruneSlackBytes = 2LL << 30;
+static const long long kMinFreeReserveBytes = 4LL << 30;
+static const long long kMaxFreeReserveBytes = 16LL << 30;
+static const char * kPerformancePrefSection = "performance";
+static const char * kPerformanceCacheArtifactKey = "cache_artifact";
 
 struct PackEntryHeader {
 	unsigned int magic;
@@ -146,6 +160,39 @@ static std::string HexU64(unsigned long long value)
 static long long NowUnixSeconds()
 {
 	return static_cast<long long>(time(nullptr));
+}
+
+static bool ReadArtifactCacheEnabledPref()
+{
+	return atoi(GUI_GetPrefString(kPerformancePrefSection, kPerformanceCacheArtifactKey, "1")) != 0;
+}
+
+static std::string MakeSegmentFileName(long long sequence)
+{
+	char buf[64] = { 0 };
+	snprintf(buf, sizeof(buf), "pack-%06lld.dat", sequence);
+	return std::string(buf);
+}
+
+static bool QueryVolumeSpace(const std::string& path, unsigned long long& out_free_bytes, unsigned long long& out_total_bytes)
+{
+#if IBM
+	ULARGE_INTEGER free_bytes = { 0 };
+	ULARGE_INTEGER total_bytes = { 0 };
+	ULARGE_INTEGER total_free_bytes = { 0 };
+	if (!GetDiskFreeSpaceExA(path.c_str(), &free_bytes, &total_bytes, &total_free_bytes))
+		return false;
+	out_free_bytes = free_bytes.QuadPart;
+	out_total_bytes = total_bytes.QuadPart;
+	return true;
+#else
+	struct statvfs fs = { 0 };
+	if (statvfs(path.c_str(), &fs) != 0)
+		return false;
+	out_free_bytes = static_cast<unsigned long long>(fs.f_bavail) * static_cast<unsigned long long>(fs.f_frsize);
+	out_total_bytes = static_cast<unsigned long long>(fs.f_blocks) * static_cast<unsigned long long>(fs.f_frsize);
+	return true;
+#endif
 }
 
 static void WriteString(BlobWriter& writer, const std::string& value)
@@ -749,10 +796,11 @@ WED_ResourceCache& WED_ResourceCache::Get()
 }
 
 WED_ResourceCache::WED_ResourceCache() :
-	mEnabled(EnvFlagEnabledOrDefault("WED_RESOURCE_CACHE_V2", true)),
+	mEnabled(EnvFlagEnabledOrDefault("WED_RESOURCE_CACHE_V2", ReadArtifactCacheEnabledPref())),
 	mInitAttempted(false),
 	mOpenOk(false),
-	mActivePackName(kPackFileName),
+	mActivePackSize(0),
+	mNextPackSequence(1),
 	mDb(nullptr)
 {
 	const char * local_app_data = getenv("LOCALAPPDATA");
@@ -780,6 +828,28 @@ std::string WED_ResourceCache::GetRootPath() const
 	return mRootPath;
 }
 
+void WED_ResourceCache::SetEnabled(bool enabled)
+{
+	std::lock_guard<std::mutex> guard(mMutex);
+	mEnabled = enabled;
+	CloseLocked();
+	mInitAttempted = false;
+	mActivePackName.clear();
+	mActivePackSize = 0;
+	mNextPackSequence = 1;
+}
+
+bool WED_ResourceCache::Clear()
+{
+	std::lock_guard<std::mutex> guard(mMutex);
+	CloseLocked();
+	mInitAttempted = false;
+	mActivePackName.clear();
+	mActivePackSize = 0;
+	mNextPackSequence = 1;
+	return ResetStorageLocked();
+}
+
 bool WED_ResourceCache::EnsureOpenLocked()
 {
 	if (!mEnabled)
@@ -788,6 +858,8 @@ bool WED_ResourceCache::EnsureOpenLocked()
 		return mOpenOk;
 
 	mInitAttempted = true;
+	if (FILE_make_dir_exist(mRootPath.c_str()) != 0)
+		return false;
 	if (FILE_make_dir_exist(mPackDirPath.c_str()) != 0)
 		return false;
 
@@ -802,6 +874,58 @@ bool WED_ResourceCache::EnsureOpenLocked()
 	ExecSql(mDb, "PRAGMA journal_mode=WAL;");
 	ExecSql(mDb, "PRAGMA synchronous=NORMAL;");
 	ExecSql(mDb, "PRAGMA temp_store=MEMORY;");
+	if (!EnsureSchemaLocked())
+	{
+		CloseLocked();
+		return false;
+	}
+
+	ExecSql(mDb, "UPDATE segments SET sealed = 1;");
+	mActivePackName.clear();
+	mActivePackSize = 0;
+
+	const long long current_total = QueryTotalSegmentBytesLocked();
+	const long long effective_cap = ComputeEffectiveHardCapBytesLocked(current_total);
+	if (current_total > effective_cap)
+	{
+		const long long prune_target = ComputePruneTargetBytesLocked(effective_cap);
+		while (QueryTotalSegmentBytesLocked() > prune_target)
+		{
+			SegmentRecord record;
+			if (!FindOldestSealedPackLocked(record))
+				break;
+			if (!DeletePackLocked(record))
+				break;
+		}
+	}
+
+	mOpenOk = true;
+	return true;
+}
+
+void WED_ResourceCache::CloseLocked()
+{
+	if (mDb != nullptr)
+	{
+		sqlite3_close(mDb);
+		mDb = nullptr;
+	}
+	mOpenOk = false;
+	mActivePackName.clear();
+	mActivePackSize = 0;
+}
+
+bool WED_ResourceCache::EnsureSchemaLocked()
+{
+	if (!ExecSql(mDb,
+		"CREATE TABLE IF NOT EXISTS meta ("
+		"key TEXT PRIMARY KEY,"
+		"value INTEGER NOT NULL"
+		");"))
+	{
+		return false;
+	}
+
 	if (!ExecSql(mDb,
 		"CREATE TABLE IF NOT EXISTS artifacts ("
 		"cache_key TEXT PRIMARY KEY,"
@@ -819,22 +943,133 @@ bool WED_ResourceCache::EnsureOpenLocked()
 		"hit_count INTEGER NOT NULL DEFAULT 0"
 		");"))
 	{
-		CloseLocked();
 		return false;
 	}
 
-	mOpenOk = true;
+	if (!ExecSql(mDb,
+		"CREATE TABLE IF NOT EXISTS segments ("
+		"pack_name TEXT PRIMARY KEY,"
+		"sequence INTEGER NOT NULL,"
+		"created_at INTEGER NOT NULL,"
+		"total_bytes INTEGER NOT NULL,"
+		"sealed INTEGER NOT NULL"
+		");"))
+	{
+		return false;
+	}
+
+	ExecSql(mDb, "CREATE INDEX IF NOT EXISTS idx_artifacts_pack_name ON artifacts(pack_name);");
+	ExecSql(mDb, "CREATE INDEX IF NOT EXISTS idx_segments_sequence ON segments(sequence);");
+
+	long long layout_version = 0;
+	sqlite3_stmt * meta_stmt = nullptr;
+	const bool has_meta_value =
+		sqlite3_prepare_v2(mDb, "SELECT value FROM meta WHERE key = 'layout_version';", -1, &meta_stmt, nullptr) == SQLITE_OK &&
+		sqlite3_step(meta_stmt) == SQLITE_ROW;
+	if (has_meta_value)
+		layout_version = sqlite3_column_int64(meta_stmt, 0);
+	if (meta_stmt != nullptr)
+		sqlite3_finalize(meta_stmt);
+
+	if (!has_meta_value || layout_version != kCacheLayoutVersion)
+	{
+		CloseLocked();
+		if (!ResetStorageLocked())
+			return false;
+		if (sqlite3_open(mDbPath.c_str(), &mDb) != SQLITE_OK)
+		{
+			if (mDb)
+				sqlite3_close(mDb);
+			mDb = nullptr;
+			return false;
+		}
+		ExecSql(mDb, "PRAGMA journal_mode=WAL;");
+		ExecSql(mDb, "PRAGMA synchronous=NORMAL;");
+		ExecSql(mDb, "PRAGMA temp_store=MEMORY;");
+		if (!ExecSql(mDb,
+			"CREATE TABLE IF NOT EXISTS meta ("
+			"key TEXT PRIMARY KEY,"
+			"value INTEGER NOT NULL"
+			");") ||
+			!ExecSql(mDb,
+			"CREATE TABLE IF NOT EXISTS artifacts ("
+			"cache_key TEXT PRIMARY KEY,"
+			"kind INTEGER NOT NULL,"
+			"schema_version INTEGER NOT NULL,"
+			"flags INTEGER NOT NULL,"
+			"source_path TEXT NOT NULL,"
+			"source_size INTEGER NOT NULL,"
+			"source_mtime INTEGER NOT NULL,"
+			"pack_name TEXT NOT NULL,"
+			"pack_offset INTEGER NOT NULL,"
+			"pack_size INTEGER NOT NULL,"
+			"created_at INTEGER NOT NULL,"
+			"last_access INTEGER NOT NULL,"
+			"hit_count INTEGER NOT NULL DEFAULT 0"
+			");") ||
+			!ExecSql(mDb,
+			"CREATE TABLE IF NOT EXISTS segments ("
+			"pack_name TEXT PRIMARY KEY,"
+			"sequence INTEGER NOT NULL,"
+			"created_at INTEGER NOT NULL,"
+			"total_bytes INTEGER NOT NULL,"
+			"sealed INTEGER NOT NULL"
+			");"))
+		{
+			return false;
+		}
+		ExecSql(mDb, "CREATE INDEX IF NOT EXISTS idx_artifacts_pack_name ON artifacts(pack_name);");
+		ExecSql(mDb, "CREATE INDEX IF NOT EXISTS idx_segments_sequence ON segments(sequence);");
+		sqlite3_stmt * insert_stmt = nullptr;
+		if (sqlite3_prepare_v2(mDb, "INSERT OR REPLACE INTO meta (key, value) VALUES ('layout_version', ?1), ('next_pack_sequence', ?2);", -1, &insert_stmt, nullptr) == SQLITE_OK)
+		{
+			sqlite3_bind_int64(insert_stmt, 1, kCacheLayoutVersion);
+			sqlite3_bind_int64(insert_stmt, 2, 1);
+			sqlite3_step(insert_stmt);
+			sqlite3_finalize(insert_stmt);
+		}
+		mNextPackSequence = 1;
+		return true;
+	}
+
+	sqlite3_stmt * seq_stmt = nullptr;
+	if (sqlite3_prepare_v2(mDb, "SELECT value FROM meta WHERE key = 'next_pack_sequence';", -1, &seq_stmt, nullptr) == SQLITE_OK &&
+		sqlite3_step(seq_stmt) == SQLITE_ROW)
+	{
+		mNextPackSequence = sqlite3_column_int64(seq_stmt, 0);
+	}
+	else
+	{
+		mNextPackSequence = 1;
+		sqlite3_stmt * insert_stmt = nullptr;
+		if (sqlite3_prepare_v2(mDb, "INSERT OR REPLACE INTO meta (key, value) VALUES ('next_pack_sequence', ?1);", -1, &insert_stmt, nullptr) == SQLITE_OK)
+		{
+			sqlite3_bind_int64(insert_stmt, 1, mNextPackSequence);
+			sqlite3_step(insert_stmt);
+			sqlite3_finalize(insert_stmt);
+		}
+	}
+	if (seq_stmt != nullptr)
+		sqlite3_finalize(seq_stmt);
 	return true;
 }
 
-void WED_ResourceCache::CloseLocked()
+bool WED_ResourceCache::ResetStorageLocked()
 {
-	if (mDb != nullptr)
+	if (FILE_exists(mRootPath.c_str()))
 	{
-		sqlite3_close(mDb);
-		mDb = nullptr;
+		const string delete_path = mRootPath + DIR_STR;
+		const int delete_rc = FILE_delete_dir_recursive(delete_path);
+		if (delete_rc != 0)
+			return false;
 	}
-	mOpenOk = false;
+	const int mk_root_rc = FILE_make_dir_exist(mRootPath.c_str());
+	if (mk_root_rc != 0)
+		return false;
+	const int mk_pack_rc = FILE_make_dir_exist(mPackDirPath.c_str());
+	if (mk_pack_rc != 0)
+		return false;
+	return true;
 }
 
 WED_ResourceCache::SourceFingerprint WED_ResourceCache::MakeFingerprint(const std::string& source_path) const
@@ -866,6 +1101,216 @@ std::string WED_ResourceCache::BuildCacheKey(ArtifactKind kind, const SourceFing
 	return HexU64(Fnv1a64(key_material));
 }
 
+bool WED_ResourceCache::EnsureActivePackLocked()
+{
+	if (!mActivePackName.empty())
+		return true;
+	return CreateNewActivePackLocked();
+}
+
+bool WED_ResourceCache::CreateNewActivePackLocked()
+{
+	const std::string pack_name = MakeSegmentFileName(mNextPackSequence);
+	sqlite3_stmt * stmt = nullptr;
+	if (sqlite3_prepare_v2(
+			mDb,
+			"INSERT INTO segments (pack_name, sequence, created_at, total_bytes, sealed) VALUES (?1, ?2, ?3, 0, 0);",
+			-1,
+			&stmt,
+			nullptr) != SQLITE_OK)
+	{
+		return false;
+	}
+
+	const long long now = NowUnixSeconds();
+	sqlite3_bind_text(stmt, 1, pack_name.c_str(), -1, SQLITE_TRANSIENT);
+	sqlite3_bind_int64(stmt, 2, mNextPackSequence);
+	sqlite3_bind_int64(stmt, 3, now);
+	const bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+	sqlite3_finalize(stmt);
+	if (!ok)
+		return false;
+
+	sqlite3_stmt * meta_stmt = nullptr;
+	if (sqlite3_prepare_v2(mDb, "INSERT OR REPLACE INTO meta (key, value) VALUES ('next_pack_sequence', ?1);", -1, &meta_stmt, nullptr) == SQLITE_OK)
+	{
+		sqlite3_bind_int64(meta_stmt, 1, mNextPackSequence + 1);
+		sqlite3_step(meta_stmt);
+		sqlite3_finalize(meta_stmt);
+	}
+	++mNextPackSequence;
+
+	const std::string pack_path = mPackDirPath + DIR_STR + pack_name;
+	FILE * file = fopen(pack_path.c_str(), "ab");
+	if (file == nullptr)
+		return false;
+	fclose(file);
+
+	mActivePackName = pack_name;
+	mActivePackSize = 0;
+	return true;
+}
+
+void WED_ResourceCache::SealActivePackLocked()
+{
+	if (mActivePackName.empty())
+		return;
+
+	sqlite3_stmt * stmt = nullptr;
+	if (sqlite3_prepare_v2(mDb, "UPDATE segments SET sealed = 1 WHERE pack_name = ?1;", -1, &stmt, nullptr) == SQLITE_OK)
+	{
+		sqlite3_bind_text(stmt, 1, mActivePackName.c_str(), -1, SQLITE_TRANSIENT);
+		sqlite3_step(stmt);
+		sqlite3_finalize(stmt);
+	}
+	mActivePackName.clear();
+	mActivePackSize = 0;
+}
+
+bool WED_ResourceCache::FindOldestSealedPackLocked(SegmentRecord& out_record)
+{
+	out_record = SegmentRecord();
+	sqlite3_stmt * stmt = nullptr;
+	if (sqlite3_prepare_v2(
+			mDb,
+			"SELECT pack_name, sequence, total_bytes, sealed FROM segments WHERE sealed = 1 ORDER BY sequence ASC LIMIT 1;",
+			-1,
+			&stmt,
+			nullptr) != SQLITE_OK)
+	{
+		return false;
+	}
+
+	if (sqlite3_step(stmt) != SQLITE_ROW)
+	{
+		sqlite3_finalize(stmt);
+		return false;
+	}
+
+	const unsigned char * pack_name_text = sqlite3_column_text(stmt, 0);
+	out_record.pack_name = pack_name_text ? reinterpret_cast<const char *>(pack_name_text) : "";
+	out_record.sequence = sqlite3_column_int64(stmt, 1);
+	out_record.total_bytes = sqlite3_column_int64(stmt, 2);
+	out_record.sealed = sqlite3_column_int(stmt, 3) != 0;
+	out_record.valid = !out_record.pack_name.empty();
+	sqlite3_finalize(stmt);
+	return out_record.valid;
+}
+
+bool WED_ResourceCache::DeletePackLocked(const SegmentRecord& record)
+{
+	if (!record.valid || record.pack_name.empty())
+		return false;
+
+	const std::string pack_path = mPackDirPath + DIR_STR + record.pack_name;
+	if (FILE_exists(pack_path.c_str()) && FILE_delete_file(pack_path.c_str(), false) != 0)
+		return false;
+
+	ExecSql(mDb, "BEGIN IMMEDIATE TRANSACTION;");
+
+	bool ok = true;
+	sqlite3_stmt * delete_artifacts = nullptr;
+	if (sqlite3_prepare_v2(mDb, "DELETE FROM artifacts WHERE pack_name = ?1;", -1, &delete_artifacts, nullptr) == SQLITE_OK)
+	{
+		sqlite3_bind_text(delete_artifacts, 1, record.pack_name.c_str(), -1, SQLITE_TRANSIENT);
+		ok = sqlite3_step(delete_artifacts) == SQLITE_DONE;
+		sqlite3_finalize(delete_artifacts);
+	}
+	else
+	{
+		ok = false;
+	}
+
+	sqlite3_stmt * delete_segment = nullptr;
+	if (ok && sqlite3_prepare_v2(mDb, "DELETE FROM segments WHERE pack_name = ?1;", -1, &delete_segment, nullptr) == SQLITE_OK)
+	{
+		sqlite3_bind_text(delete_segment, 1, record.pack_name.c_str(), -1, SQLITE_TRANSIENT);
+		ok = sqlite3_step(delete_segment) == SQLITE_DONE;
+		sqlite3_finalize(delete_segment);
+	}
+	else if (ok)
+	{
+		ok = false;
+	}
+
+	ExecSql(mDb, ok ? "COMMIT;" : "ROLLBACK;");
+	return ok;
+}
+
+long long WED_ResourceCache::QueryTotalSegmentBytesLocked() const
+{
+	sqlite3_stmt * stmt = nullptr;
+	long long total_bytes = 0;
+	if (sqlite3_prepare_v2(mDb, "SELECT COALESCE(SUM(total_bytes), 0) FROM segments;", -1, &stmt, nullptr) == SQLITE_OK)
+	{
+		if (sqlite3_step(stmt) == SQLITE_ROW)
+			total_bytes = sqlite3_column_int64(stmt, 0);
+		sqlite3_finalize(stmt);
+	}
+	return total_bytes;
+}
+
+long long WED_ResourceCache::ComputeEffectiveHardCapBytesLocked(long long current_total_bytes) const
+{
+	unsigned long long free_bytes = 0;
+	unsigned long long total_bytes = 0;
+	if (!QueryVolumeSpace(mRootPath, free_bytes, total_bytes))
+		return kConfiguredHardCapBytes;
+
+	const long long reserve_bytes = std::max<long long>(
+		kMinFreeReserveBytes,
+		std::min<long long>(kMaxFreeReserveBytes, static_cast<long long>(total_bytes / 20)));
+	const long long volume_limited_cap = std::max<long long>(
+		0,
+		current_total_bytes + static_cast<long long>(free_bytes) - reserve_bytes);
+	return std::min<long long>(kConfiguredHardCapBytes, volume_limited_cap);
+}
+
+long long WED_ResourceCache::ComputePruneTargetBytesLocked(long long effective_hard_cap_bytes) const
+{
+	return std::max<long long>(0, effective_hard_cap_bytes - kPruneSlackBytes);
+}
+
+bool WED_ResourceCache::EnsureCapacityForWriteLocked(long long entry_size)
+{
+	if (entry_size <= 0 || entry_size > kSegmentSizeBytes)
+		return false;
+	if (!EnsureActivePackLocked())
+		return false;
+
+	if (mActivePackSize + entry_size > kSegmentSizeBytes)
+	{
+		SealActivePackLocked();
+		if (!CreateNewActivePackLocked())
+			return false;
+	}
+
+	long long current_total = QueryTotalSegmentBytesLocked();
+	long long effective_hard_cap = ComputeEffectiveHardCapBytesLocked(current_total);
+	if (current_total + entry_size <= effective_hard_cap)
+		return true;
+
+	const long long prune_target = ComputePruneTargetBytesLocked(effective_hard_cap);
+	const long long target_before_write = std::min<long long>(
+		prune_target,
+		std::max<long long>(0, effective_hard_cap - entry_size));
+
+	while (current_total > target_before_write)
+	{
+		SegmentRecord record;
+		if (!FindOldestSealedPackLocked(record))
+			break;
+		if (!DeletePackLocked(record))
+			break;
+		current_total = QueryTotalSegmentBytesLocked();
+		effective_hard_cap = ComputeEffectiveHardCapBytesLocked(current_total);
+	}
+
+	current_total = QueryTotalSegmentBytesLocked();
+	effective_hard_cap = ComputeEffectiveHardCapBytesLocked(current_total);
+	return current_total + entry_size <= effective_hard_cap;
+}
+
 bool WED_ResourceCache::LookupArtifactLocked(ArtifactKind kind, const std::string& cache_key, ArtifactRecord& out_record)
 {
 	if (!EnsureOpenLocked())
@@ -891,15 +1336,6 @@ bool WED_ResourceCache::LookupArtifactLocked(ArtifactKind kind, const std::strin
 	out_record.size = sqlite3_column_int64(stmt, 2);
 	out_record.valid = true;
 	sqlite3_finalize(stmt);
-
-	sqlite3_stmt * touch = nullptr;
-	if (sqlite3_prepare_v2(mDb, "UPDATE artifacts SET last_access = ?2, hit_count = hit_count + 1 WHERE cache_key = ?1;", -1, &touch, nullptr) == SQLITE_OK)
-	{
-		sqlite3_bind_text(touch, 1, cache_key.c_str(), -1, SQLITE_TRANSIENT);
-		sqlite3_bind_int64(touch, 2, NowUnixSeconds());
-		sqlite3_step(touch);
-		sqlite3_finalize(touch);
-	}
 
 	return true;
 }
@@ -948,6 +1384,10 @@ void WED_ResourceCache::StoreArtifactLocked(ArtifactKind kind, const SourceFinge
 	if (!EnsureOpenLocked())
 		return;
 
+	const long long entry_size = static_cast<long long>(sizeof(PackEntryHeader) + payload.size());
+	if (!EnsureCapacityForWriteLocked(entry_size))
+		return;
+
 	const std::string pack_path = mPackDirPath + DIR_STR + mActivePackName;
 	FILE * file = fopen(pack_path.c_str(), "ab");
 	if (file == nullptr)
@@ -965,7 +1405,11 @@ void WED_ResourceCache::StoreArtifactLocked(ArtifactKind kind, const SourceFinge
 	if (!wrote_header || !wrote_payload)
 		return;
 
+	mActivePackSize += entry_size;
+
 	const std::string cache_key = BuildCacheKey(kind, fp, flags, schema_version);
+	ExecSql(mDb, "BEGIN IMMEDIATE TRANSACTION;");
+
 	sqlite3_stmt * stmt = nullptr;
 	if (sqlite3_prepare_v2(
 		mDb,
@@ -975,6 +1419,7 @@ void WED_ResourceCache::StoreArtifactLocked(ArtifactKind kind, const SourceFinge
 		&stmt,
 		nullptr) != SQLITE_OK)
 	{
+		ExecSql(mDb, "ROLLBACK;");
 		return;
 	}
 
@@ -990,8 +1435,26 @@ void WED_ResourceCache::StoreArtifactLocked(ArtifactKind kind, const SourceFinge
 	sqlite3_bind_int64(stmt, 9, offset);
 	sqlite3_bind_int64(stmt, 10, static_cast<sqlite3_int64>(sizeof(header) + payload.size()));
 	sqlite3_bind_int64(stmt, 11, now);
-	sqlite3_step(stmt);
+	const bool insert_ok = sqlite3_step(stmt) == SQLITE_DONE;
 	sqlite3_finalize(stmt);
+	if (!insert_ok)
+	{
+		ExecSql(mDb, "ROLLBACK;");
+		return;
+	}
+
+	sqlite3_stmt * segment_stmt = nullptr;
+	if (sqlite3_prepare_v2(mDb, "UPDATE segments SET total_bytes = ?2 WHERE pack_name = ?1;", -1, &segment_stmt, nullptr) != SQLITE_OK)
+	{
+		ExecSql(mDb, "ROLLBACK;");
+		return;
+	}
+
+	sqlite3_bind_text(segment_stmt, 1, mActivePackName.c_str(), -1, SQLITE_TRANSIENT);
+	sqlite3_bind_int64(segment_stmt, 2, mActivePackSize);
+	const bool segment_ok = sqlite3_step(segment_stmt) == SQLITE_DONE;
+	sqlite3_finalize(segment_stmt);
+	ExecSql(mDb, segment_ok ? "COMMIT;" : "ROLLBACK;");
 }
 
 bool WED_ResourceCache::LoadObjMeta(const std::string& source_path, WED_ResourceCacheObjMeta& out_meta)

--- a/src/WEDCore/WED_ResourceCache.cpp
+++ b/src/WEDCore/WED_ResourceCache.cpp
@@ -36,6 +36,7 @@ static const int kObjMetaSchemaVersion = 1;
 static const int kObjGeomSchemaVersion = 1;
 static const int kTexPreparedSchemaVersion = 1;
 static const int kTexCompressedSchemaVersion = 1;
+static const int kNavaidIndexSchemaVersion = 1;
 static const int kCacheLayoutVersion = 3;
 static const unsigned int kPackMagic = 0x32524357;  // WCR2
 static const long long kSegmentSizeBytes = 1LL << 30;
@@ -1085,6 +1086,16 @@ WED_ResourceCache::SourceFingerprint WED_ResourceCache::MakeFingerprint(const st
 	return fp;
 }
 
+WED_ResourceCache::SourceFingerprint WED_ResourceCache::MakeVirtualFingerprint(const std::string& source_identity) const
+{
+	SourceFingerprint fp;
+	fp.normalized_path = NormalizePathForKey(std::string("virtual:") + source_identity);
+	fp.size = 0;
+	fp.mtime = 0;
+	fp.valid = !source_identity.empty();
+	return fp;
+}
+
 std::string WED_ResourceCache::BuildCacheKey(ArtifactKind kind, const SourceFingerprint& fp, int flags, int schema_version) const
 {
 	std::string key_material = fp.normalized_path;
@@ -1590,4 +1601,25 @@ void WED_ResourceCache::StoreCompressedTexture(const std::string& source_path, i
 	if (!fp.valid)
 		return;
 	StoreArtifactLocked(artifact_TexCompressed, fp, flags, kTexCompressedSchemaVersion, SerializeCompressedTexture(image));
+}
+
+bool WED_ResourceCache::LoadNavaidIndex(const std::string& source_signature, std::vector<unsigned char>& out_payload)
+{
+	std::lock_guard<std::mutex> guard(mMutex);
+	const SourceFingerprint fp = MakeVirtualFingerprint(source_signature);
+	if (!fp.valid)
+		return false;
+	const std::string cache_key = BuildCacheKey(artifact_NavaidIndex, fp, 0, kNavaidIndexSchemaVersion);
+	ArtifactRecord record;
+	return LookupArtifactLocked(artifact_NavaidIndex, cache_key, record) &&
+		ReadArtifactLocked(artifact_NavaidIndex, record, out_payload);
+}
+
+void WED_ResourceCache::StoreNavaidIndex(const std::string& source_signature, const std::vector<unsigned char>& payload)
+{
+	std::lock_guard<std::mutex> guard(mMutex);
+	const SourceFingerprint fp = MakeVirtualFingerprint(source_signature);
+	if (!fp.valid)
+		return;
+	StoreArtifactLocked(artifact_NavaidIndex, fp, 0, kNavaidIndexSchemaVersion, payload);
 }

--- a/src/WEDCore/WED_ResourceCache.cpp
+++ b/src/WEDCore/WED_ResourceCache.cpp
@@ -28,6 +28,7 @@ namespace {
 static const int kObjMetaSchemaVersion = 1;
 static const int kObjGeomSchemaVersion = 1;
 static const int kTexPreparedSchemaVersion = 1;
+static const int kTexCompressedSchemaVersion = 1;
 static const char * kPackFileName = "artifacts.pack";
 static const unsigned int kPackMagic = 0x32524357;  // WCR2
 
@@ -662,6 +663,67 @@ static bool DeserializePreparedTexture(const std::vector<unsigned char>& bytes, 
 	return reader.Done();
 }
 
+static std::vector<unsigned char> SerializeCompressedTexture(const CompressedTextureImage& image)
+{
+	BlobWriter writer;
+	writer.WritePod(image.data_size);
+	writer.WritePod(image.internal_format);
+	writer.WritePod(image.width);
+	writer.WritePod(image.height);
+	writer.WritePod(image.level_count);
+	writer.WritePod(image.org_x);
+	writer.WritePod(image.org_y);
+	writer.WritePod(image.act_x);
+	writer.WritePod(image.act_y);
+	writer.WritePod(image.vis_x);
+	writer.WritePod(image.vis_y);
+	WriteIntVector(writer, image.level_sizes);
+	if (image.data_size > 0 && image.data != nullptr)
+		writer.WriteBytes(image.data, image.data_size);
+	return writer.data;
+}
+
+static bool DeserializeCompressedTexture(const std::vector<unsigned char>& bytes, CompressedTextureImage& out_image)
+{
+	DestroyCompressedTextureImage(&out_image);
+	BlobReader reader(bytes.data(), bytes.data() + bytes.size());
+	if (!reader.ReadPod(out_image.data_size) ||
+		!reader.ReadPod(out_image.internal_format) ||
+		!reader.ReadPod(out_image.width) ||
+		!reader.ReadPod(out_image.height) ||
+		!reader.ReadPod(out_image.level_count) ||
+		!reader.ReadPod(out_image.org_x) ||
+		!reader.ReadPod(out_image.org_y) ||
+		!reader.ReadPod(out_image.act_x) ||
+		!reader.ReadPod(out_image.act_y) ||
+		!reader.ReadPod(out_image.vis_x) ||
+		!reader.ReadPod(out_image.vis_y) ||
+		!ReadIntVector(reader, out_image.level_sizes))
+		return false;
+
+	if (out_image.data_size <= 0 ||
+		out_image.internal_format == 0 ||
+		out_image.width <= 0 ||
+		out_image.height <= 0 ||
+		out_image.level_count <= 0 ||
+		static_cast<int>(out_image.level_sizes.size()) != out_image.level_count)
+	{
+		DestroyCompressedTextureImage(&out_image);
+		return false;
+	}
+
+	out_image.data = reinterpret_cast<unsigned char *>(malloc(out_image.data_size));
+	if (out_image.data == nullptr)
+		return false;
+	if (!reader.ReadBytes(out_image.data, out_image.data_size))
+	{
+		DestroyCompressedTextureImage(&out_image);
+		return false;
+	}
+
+	return reader.Done();
+}
+
 static bool ExecSql(sqlite3 * db, const char * sql)
 {
 	return sqlite3_exec(db, sql, nullptr, nullptr, nullptr) == SQLITE_OK;
@@ -979,18 +1041,39 @@ void WED_ResourceCache::StoreObjGeom(const std::string& source_path, const XObj8
 	StoreArtifactLocked(artifact_ObjMeta, fp, 0, kObjMetaSchemaVersion, SerializeObjMeta(ExtractObjMeta(obj)));
 }
 
-bool WED_ResourceCache::LoadPreparedTexture(const std::string& source_path, int flags, PreparedTextureImage& out_image)
+bool WED_ResourceCache::LoadPreparedTexture(const std::string& source_path, int flags, PreparedTextureImage& out_image, WED_ResourceCachePreparedTextureLoadPerf * out_perf)
 {
 	std::lock_guard<std::mutex> guard(mMutex);
+	if (out_perf != nullptr)
+		*out_perf = WED_ResourceCachePreparedTextureLoadPerf();
+
+	const auto total_begin = out_perf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
 	const SourceFingerprint fp = MakeFingerprint(source_path);
 	if (!fp.valid)
 		return false;
 	const std::string cache_key = BuildCacheKey(artifact_TexPrepared, fp, flags, kTexPreparedSchemaVersion);
 	ArtifactRecord record;
-	if (!LookupArtifactLocked(artifact_TexPrepared, cache_key, record))
+	const auto lookup_begin = out_perf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+	const bool found = LookupArtifactLocked(artifact_TexPrepared, cache_key, record);
+	if (out_perf != nullptr)
+		out_perf->lookup_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - lookup_begin).count();
+	if (!found)
 		return false;
 	std::vector<unsigned char> payload;
-	return ReadArtifactLocked(artifact_TexPrepared, record, payload) && DeserializePreparedTexture(payload, out_image);
+	const auto read_begin = out_perf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+	const bool read_ok = ReadArtifactLocked(artifact_TexPrepared, record, payload);
+	if (out_perf != nullptr)
+		out_perf->read_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - read_begin).count();
+	if (!read_ok)
+		return false;
+	const auto deserialize_begin = out_perf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+	const bool deserialize_ok = DeserializePreparedTexture(payload, out_image);
+	if (out_perf != nullptr)
+	{
+		out_perf->deserialize_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - deserialize_begin).count();
+		out_perf->total_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - total_begin).count();
+	}
+	return deserialize_ok;
 }
 
 void WED_ResourceCache::StorePreparedTexture(const std::string& source_path, int flags, const PreparedTextureImage& image)
@@ -1000,4 +1083,48 @@ void WED_ResourceCache::StorePreparedTexture(const std::string& source_path, int
 	if (!fp.valid)
 		return;
 	StoreArtifactLocked(artifact_TexPrepared, fp, flags, kTexPreparedSchemaVersion, SerializePreparedTexture(image));
+}
+
+bool WED_ResourceCache::LoadCompressedTexture(const std::string& source_path, int flags, CompressedTextureImage& out_image, WED_ResourceCachePreparedTextureLoadPerf * out_perf)
+{
+	std::lock_guard<std::mutex> guard(mMutex);
+	if (out_perf != nullptr)
+		*out_perf = WED_ResourceCachePreparedTextureLoadPerf();
+
+	const auto total_begin = out_perf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+	const SourceFingerprint fp = MakeFingerprint(source_path);
+	if (!fp.valid)
+		return false;
+	const std::string cache_key = BuildCacheKey(artifact_TexCompressed, fp, flags, kTexCompressedSchemaVersion);
+	ArtifactRecord record;
+	const auto lookup_begin = out_perf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+	const bool found = LookupArtifactLocked(artifact_TexCompressed, cache_key, record);
+	if (out_perf != nullptr)
+		out_perf->lookup_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - lookup_begin).count();
+	if (!found)
+		return false;
+	std::vector<unsigned char> payload;
+	const auto read_begin = out_perf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+	const bool read_ok = ReadArtifactLocked(artifact_TexCompressed, record, payload);
+	if (out_perf != nullptr)
+		out_perf->read_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - read_begin).count();
+	if (!read_ok)
+		return false;
+	const auto deserialize_begin = out_perf != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+	const bool deserialize_ok = DeserializeCompressedTexture(payload, out_image);
+	if (out_perf != nullptr)
+	{
+		out_perf->deserialize_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - deserialize_begin).count();
+		out_perf->total_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - total_begin).count();
+	}
+	return deserialize_ok;
+}
+
+void WED_ResourceCache::StoreCompressedTexture(const std::string& source_path, int flags, const CompressedTextureImage& image)
+{
+	std::lock_guard<std::mutex> guard(mMutex);
+	const SourceFingerprint fp = MakeFingerprint(source_path);
+	if (!fp.valid)
+		return;
+	StoreArtifactLocked(artifact_TexCompressed, fp, flags, kTexCompressedSchemaVersion, SerializeCompressedTexture(image));
 }

--- a/src/WEDCore/WED_ResourceCache.cpp
+++ b/src/WEDCore/WED_ResourceCache.cpp
@@ -1,0 +1,1003 @@
+/*
+ * Copyright (c) 2026
+ */
+
+#include "WED_ResourceCache.h"
+
+#include "FileUtils.h"
+#include "MemFileUtils.h"
+#include "PlatformUtils.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <sys/stat.h>
+
+extern "C" {
+#include "sqlite3.h"
+}
+
+namespace {
+
+static const int kObjMetaSchemaVersion = 1;
+static const int kObjGeomSchemaVersion = 1;
+static const int kTexPreparedSchemaVersion = 1;
+static const char * kPackFileName = "artifacts.pack";
+static const unsigned int kPackMagic = 0x32524357;  // WCR2
+
+struct PackEntryHeader {
+	unsigned int magic;
+	unsigned int kind;
+	unsigned long long payload_size;
+	unsigned int reserved;
+};
+
+struct BlobWriter {
+	std::vector<unsigned char> data;
+
+	template <typename T>
+	void WritePod(const T& value)
+	{
+		const unsigned char * begin = reinterpret_cast<const unsigned char *>(&value);
+		data.insert(data.end(), begin, begin + sizeof(T));
+	}
+
+	void WriteBytes(const void * src, size_t len)
+	{
+		const unsigned char * begin = reinterpret_cast<const unsigned char *>(src);
+		data.insert(data.end(), begin, begin + len);
+	}
+};
+
+struct BlobReader {
+	const unsigned char * cur;
+	const unsigned char * end;
+
+	BlobReader(const unsigned char * in_begin, const unsigned char * in_end) : cur(in_begin), end(in_end) {}
+
+	template <typename T>
+	bool ReadPod(T& value)
+	{
+		if (static_cast<size_t>(end - cur) < sizeof(T))
+			return false;
+		memcpy(&value, cur, sizeof(T));
+		cur += sizeof(T);
+		return true;
+	}
+
+	bool ReadBytes(void * dst, size_t len)
+	{
+		if (static_cast<size_t>(end - cur) < len)
+			return false;
+		memcpy(dst, cur, len);
+		cur += len;
+		return true;
+	}
+
+	bool Done() const
+	{
+		return cur == end;
+	}
+};
+
+static bool EnvFlagEnabled(const char * name)
+{
+	const char * raw = getenv(name);
+	if (raw == nullptr || raw[0] == '\0')
+		return false;
+
+	std::string lowered(raw);
+	std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](char ch) {
+		return static_cast<char>(tolower(static_cast<unsigned char>(ch)));
+	});
+	return lowered != "0" && lowered != "false" && lowered != "off" && lowered != "no";
+}
+
+static bool EnvFlagEnabledOrDefault(const char * name, bool default_value)
+{
+	const char * raw = getenv(name);
+	if (raw == nullptr || raw[0] == '\0')
+		return default_value;
+	return EnvFlagEnabled(name);
+}
+
+static std::string NormalizePathForKey(const std::string& path)
+{
+	std::string normalized(path);
+	for (char& ch : normalized)
+	{
+#if IBM
+		if (ch == '/')
+			ch = '\\';
+		ch = static_cast<char>(tolower(static_cast<unsigned char>(ch)));
+#else
+		if (ch == '\\')
+			ch = '/';
+#endif
+	}
+	return normalized;
+}
+
+static unsigned long long Fnv1a64(const std::string& value)
+{
+	unsigned long long hash = 1469598103934665603ULL;
+	for (unsigned char ch : value)
+	{
+		hash ^= static_cast<unsigned long long>(ch);
+		hash *= 1099511628211ULL;
+	}
+	return hash;
+}
+
+static std::string HexU64(unsigned long long value)
+{
+	char buf[17] = { 0 };
+	snprintf(buf, sizeof(buf), "%016llx", value);
+	return std::string(buf);
+}
+
+static long long NowUnixSeconds()
+{
+	return static_cast<long long>(time(nullptr));
+}
+
+static void WriteString(BlobWriter& writer, const std::string& value)
+{
+	unsigned int len = static_cast<unsigned int>(value.size());
+	writer.WritePod(len);
+	if (len)
+		writer.WriteBytes(value.data(), len);
+}
+
+static bool ReadString(BlobReader& reader, std::string& out_value)
+{
+	unsigned int len = 0;
+	if (!reader.ReadPod(len))
+		return false;
+	out_value.resize(len);
+	return len == 0 || reader.ReadBytes(&out_value[0], len);
+}
+
+static void WriteFloatArray(BlobWriter& writer, const float * values, size_t count)
+{
+	for (size_t i = 0; i < count; ++i)
+		writer.WritePod(values[i]);
+}
+
+static bool ReadFloatArray(BlobReader& reader, float * values, size_t count)
+{
+	for (size_t i = 0; i < count; ++i)
+	{
+		if (!reader.ReadPod(values[i]))
+			return false;
+	}
+	return true;
+}
+
+static void WriteDoubleArray(BlobWriter& writer, const double * values, size_t count)
+{
+	for (size_t i = 0; i < count; ++i)
+		writer.WritePod(values[i]);
+}
+
+static bool ReadDoubleArray(BlobReader& reader, double * values, size_t count)
+{
+	for (size_t i = 0; i < count; ++i)
+	{
+		if (!reader.ReadPod(values[i]))
+			return false;
+	}
+	return true;
+}
+
+static void WriteIntVector(BlobWriter& writer, const std::vector<int>& values)
+{
+	unsigned int count = static_cast<unsigned int>(values.size());
+	writer.WritePod(count);
+	if (count)
+		writer.WriteBytes(values.data(), count * sizeof(int));
+}
+
+static bool ReadIntVector(BlobReader& reader, std::vector<int>& values)
+{
+	unsigned int count = 0;
+	if (!reader.ReadPod(count))
+		return false;
+	values.resize(count);
+	return count == 0 || reader.ReadBytes(values.data(), count * sizeof(int));
+}
+
+static void WriteObjPointPool(BlobWriter& writer, const ObjPointPool& pool, int depth)
+{
+	unsigned int count = static_cast<unsigned int>(pool.count());
+	writer.WritePod(depth);
+	writer.WritePod(count);
+	for (unsigned int i = 0; i < count; ++i)
+		writer.WriteBytes(pool.get(static_cast<int>(i)), static_cast<size_t>(depth) * sizeof(float));
+}
+
+static bool ReadObjPointPool(BlobReader& reader, ObjPointPool& pool)
+{
+	int depth = 0;
+	unsigned int count = 0;
+	if (!reader.ReadPod(depth) || !reader.ReadPod(count))
+		return false;
+	if (depth <= 0)
+		return false;
+	pool.clear(depth);
+	pool.resize(static_cast<int>(count));
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		if (!reader.ReadBytes(pool.get(static_cast<int>(i)), static_cast<size_t>(depth) * sizeof(float)))
+			return false;
+	}
+	return true;
+}
+
+static void WriteObjKeyVector(BlobWriter& writer, const std::vector<XObjKey>& values)
+{
+	unsigned int count = static_cast<unsigned int>(values.size());
+	writer.WritePod(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		writer.WritePod(values[i].key);
+		WriteFloatArray(writer, values[i].v, 3);
+	}
+}
+
+static bool ReadObjKeyVector(BlobReader& reader, std::vector<XObjKey>& values)
+{
+	unsigned int count = 0;
+	if (!reader.ReadPod(count))
+		return false;
+	values.resize(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		if (!reader.ReadPod(values[i].key) || !ReadFloatArray(reader, values[i].v, 3))
+			return false;
+	}
+	return true;
+}
+
+static void WriteObjDetentVector(BlobWriter& writer, const std::vector<XObjDetentRange>& values)
+{
+	unsigned int count = static_cast<unsigned int>(values.size());
+	writer.WritePod(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		writer.WritePod(values[i].lo);
+		writer.WritePod(values[i].hi);
+		writer.WritePod(values[i].height);
+	}
+}
+
+static bool ReadObjDetentVector(BlobReader& reader, std::vector<XObjDetentRange>& values)
+{
+	unsigned int count = 0;
+	if (!reader.ReadPod(count))
+		return false;
+	values.resize(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		if (!reader.ReadPod(values[i].lo) ||
+			!reader.ReadPod(values[i].hi) ||
+			!reader.ReadPod(values[i].height))
+			return false;
+	}
+	return true;
+}
+
+static void WriteObjAnimationVector(BlobWriter& writer, const std::vector<XObjAnim8>& values)
+{
+	unsigned int count = static_cast<unsigned int>(values.size());
+	writer.WritePod(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		writer.WritePod(values[i].cmd);
+		WriteString(writer, values[i].dataref);
+		WriteFloatArray(writer, values[i].axis, 3);
+		writer.WritePod(values[i].loop);
+		WriteObjKeyVector(writer, values[i].keyframes);
+	}
+}
+
+static bool ReadObjAnimationVector(BlobReader& reader, std::vector<XObjAnim8>& values)
+{
+	unsigned int count = 0;
+	if (!reader.ReadPod(count))
+		return false;
+	values.resize(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		if (!reader.ReadPod(values[i].cmd) ||
+			!ReadString(reader, values[i].dataref) ||
+			!ReadFloatArray(reader, values[i].axis, 3) ||
+			!reader.ReadPod(values[i].loop) ||
+			!ReadObjKeyVector(reader, values[i].keyframes))
+			return false;
+	}
+	return true;
+}
+
+static void WriteObjManipVector(BlobWriter& writer, const std::vector<XObjManip8>& values)
+{
+	unsigned int count = static_cast<unsigned int>(values.size());
+	writer.WritePod(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		WriteString(writer, values[i].dataref1);
+		WriteString(writer, values[i].dataref2);
+		WriteFloatArray(writer, values[i].centroid, 3);
+		WriteFloatArray(writer, values[i].axis, 3);
+		writer.WritePod(values[i].angle_min);
+		writer.WritePod(values[i].angle_max);
+		writer.WritePod(values[i].lift);
+		writer.WritePod(values[i].v1_min);
+		writer.WritePod(values[i].v1_max);
+		writer.WritePod(values[i].v2_min);
+		writer.WritePod(values[i].v2_max);
+		WriteString(writer, values[i].cursor);
+		WriteString(writer, values[i].tooltip);
+		writer.WritePod(values[i].mouse_wheel_delta);
+		WriteObjKeyVector(writer, values[i].rotation_key_frames);
+		WriteObjDetentVector(writer, values[i].detents);
+	}
+}
+
+static bool ReadObjManipVector(BlobReader& reader, std::vector<XObjManip8>& values)
+{
+	unsigned int count = 0;
+	if (!reader.ReadPod(count))
+		return false;
+	values.resize(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		if (!ReadString(reader, values[i].dataref1) ||
+			!ReadString(reader, values[i].dataref2) ||
+			!ReadFloatArray(reader, values[i].centroid, 3) ||
+			!ReadFloatArray(reader, values[i].axis, 3) ||
+			!reader.ReadPod(values[i].angle_min) ||
+			!reader.ReadPod(values[i].angle_max) ||
+			!reader.ReadPod(values[i].lift) ||
+			!reader.ReadPod(values[i].v1_min) ||
+			!reader.ReadPod(values[i].v1_max) ||
+			!reader.ReadPod(values[i].v2_min) ||
+			!reader.ReadPod(values[i].v2_max) ||
+			!ReadString(reader, values[i].cursor) ||
+			!ReadString(reader, values[i].tooltip) ||
+			!reader.ReadPod(values[i].mouse_wheel_delta) ||
+			!ReadObjKeyVector(reader, values[i].rotation_key_frames) ||
+			!ReadObjDetentVector(reader, values[i].detents))
+			return false;
+	}
+	return true;
+}
+
+static void WriteObjEmitterVector(BlobWriter& writer, const std::vector<XObjEmitter8>& values)
+{
+	unsigned int count = static_cast<unsigned int>(values.size());
+	writer.WritePod(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		WriteString(writer, values[i].name);
+		WriteString(writer, values[i].dataref);
+		writer.WritePod(values[i].x);
+		writer.WritePod(values[i].y);
+		writer.WritePod(values[i].z);
+		writer.WritePod(values[i].psi);
+		writer.WritePod(values[i].the);
+		writer.WritePod(values[i].phi);
+		writer.WritePod(values[i].v_min);
+		writer.WritePod(values[i].v_max);
+	}
+}
+
+static bool ReadObjEmitterVector(BlobReader& reader, std::vector<XObjEmitter8>& values)
+{
+	unsigned int count = 0;
+	if (!reader.ReadPod(count))
+		return false;
+	values.resize(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		if (!ReadString(reader, values[i].name) ||
+			!ReadString(reader, values[i].dataref) ||
+			!reader.ReadPod(values[i].x) ||
+			!reader.ReadPod(values[i].y) ||
+			!reader.ReadPod(values[i].z) ||
+			!reader.ReadPod(values[i].psi) ||
+			!reader.ReadPod(values[i].the) ||
+			!reader.ReadPod(values[i].phi) ||
+			!reader.ReadPod(values[i].v_min) ||
+			!reader.ReadPod(values[i].v_max))
+			return false;
+	}
+	return true;
+}
+
+static void WriteObjCmdVector(BlobWriter& writer, const std::vector<XObjCmd8>& values)
+{
+	unsigned int count = static_cast<unsigned int>(values.size());
+	writer.WritePod(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		writer.WritePod(values[i].cmd);
+		WriteFloatArray(writer, values[i].params, 12);
+		WriteString(writer, values[i].name);
+		writer.WritePod(values[i].idx_offset);
+		writer.WritePod(values[i].idx_count);
+	}
+}
+
+static bool ReadObjCmdVector(BlobReader& reader, std::vector<XObjCmd8>& values)
+{
+	unsigned int count = 0;
+	if (!reader.ReadPod(count))
+		return false;
+	values.resize(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		if (!reader.ReadPod(values[i].cmd) ||
+			!ReadFloatArray(reader, values[i].params, 12) ||
+			!ReadString(reader, values[i].name) ||
+			!reader.ReadPod(values[i].idx_offset) ||
+			!reader.ReadPod(values[i].idx_count))
+			return false;
+	}
+	return true;
+}
+
+static void WriteObjLodVector(BlobWriter& writer, const std::vector<XObjLOD8>& values)
+{
+	unsigned int count = static_cast<unsigned int>(values.size());
+	writer.WritePod(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		writer.WritePod(values[i].lod_near);
+		writer.WritePod(values[i].lod_far);
+		WriteObjCmdVector(writer, values[i].cmds);
+	}
+}
+
+static bool ReadObjLodVector(BlobReader& reader, std::vector<XObjLOD8>& values)
+{
+	unsigned int count = 0;
+	if (!reader.ReadPod(count))
+		return false;
+	values.resize(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		if (!reader.ReadPod(values[i].lod_near) ||
+			!reader.ReadPod(values[i].lod_far) ||
+			!ReadObjCmdVector(reader, values[i].cmds))
+			return false;
+	}
+	return true;
+}
+
+static void WriteObjRegionVector(BlobWriter& writer, const std::vector<XObjPanelRegion8>& values)
+{
+	unsigned int count = static_cast<unsigned int>(values.size());
+	writer.WritePod(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		writer.WritePod(values[i].left);
+		writer.WritePod(values[i].bottom);
+		writer.WritePod(values[i].right);
+		writer.WritePod(values[i].top);
+	}
+}
+
+static bool ReadObjRegionVector(BlobReader& reader, std::vector<XObjPanelRegion8>& values)
+{
+	unsigned int count = 0;
+	if (!reader.ReadPod(count))
+		return false;
+	values.resize(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		if (!reader.ReadPod(values[i].left) ||
+			!reader.ReadPod(values[i].bottom) ||
+			!reader.ReadPod(values[i].right) ||
+			!reader.ReadPod(values[i].top))
+			return false;
+	}
+	return true;
+}
+
+static WED_ResourceCacheObjMeta ExtractObjMeta(const XObj8& obj)
+{
+	WED_ResourceCacheObjMeta meta;
+	meta.fixed_heading = obj.fixed_heading;
+	meta.viewpoint_height = obj.viewpoint_height;
+	for (int i = 0; i < 3; ++i)
+	{
+		meta.xyz_min[i] = obj.xyz_min[i];
+		meta.xyz_max[i] = obj.xyz_max[i];
+	}
+	return meta;
+}
+
+static std::vector<unsigned char> SerializeObjMeta(const WED_ResourceCacheObjMeta& meta)
+{
+	BlobWriter writer;
+	writer.WritePod(meta.fixed_heading);
+	writer.WritePod(meta.viewpoint_height);
+	WriteFloatArray(writer, meta.xyz_min, 3);
+	WriteFloatArray(writer, meta.xyz_max, 3);
+	return writer.data;
+}
+
+static bool DeserializeObjMeta(const std::vector<unsigned char>& bytes, WED_ResourceCacheObjMeta& out_meta)
+{
+	BlobReader reader(bytes.data(), bytes.data() + bytes.size());
+	return reader.ReadPod(out_meta.fixed_heading) &&
+		reader.ReadPod(out_meta.viewpoint_height) &&
+		ReadFloatArray(reader, out_meta.xyz_min, 3) &&
+		ReadFloatArray(reader, out_meta.xyz_max, 3) &&
+		reader.Done();
+}
+
+static std::vector<unsigned char> SerializeObjGeom(const XObj8& obj)
+{
+	BlobWriter writer;
+	WriteString(writer, obj.texture);
+	WriteString(writer, obj.texture_normal_map);
+	WriteString(writer, obj.texture_lit);
+	WriteString(writer, obj.decal_lib);
+	WriteString(writer, obj.texture_draped);
+	writer.WritePod(obj.use_metalness);
+	writer.WritePod(obj.glass_blending);
+	WriteString(writer, obj.particle_system);
+	WriteObjRegionVector(writer, obj.regions);
+	WriteIntVector(writer, obj.indices);
+	WriteObjPointPool(writer, obj.geo_tri, 8);
+	WriteObjPointPool(writer, obj.geo_lines, 6);
+	WriteObjPointPool(writer, obj.geo_lights, 6);
+	WriteObjAnimationVector(writer, obj.animation);
+	WriteObjManipVector(writer, obj.manips);
+	WriteObjEmitterVector(writer, obj.emitters);
+	WriteObjLodVector(writer, obj.lods);
+	WriteFloatArray(writer, obj.xyz_min, 3);
+	WriteFloatArray(writer, obj.xyz_max, 3);
+	WriteDoubleArray(writer, obj.loadCenter_latlon, 2);
+	writer.WritePod(obj.loadCenter_texSize);
+	writer.WritePod(obj.loadCenter_size);
+	writer.WritePod(obj.fixed_heading);
+	writer.WritePod(obj.viewpoint_height);
+	WriteString(writer, obj.description);
+	return writer.data;
+}
+
+static bool DeserializeObjGeom(const std::vector<unsigned char>& bytes, XObj8& out_obj)
+{
+	BlobReader reader(bytes.data(), bytes.data() + bytes.size());
+	if (!ReadString(reader, out_obj.texture) ||
+		!ReadString(reader, out_obj.texture_normal_map) ||
+		!ReadString(reader, out_obj.texture_lit) ||
+		!ReadString(reader, out_obj.decal_lib) ||
+		!ReadString(reader, out_obj.texture_draped) ||
+		!reader.ReadPod(out_obj.use_metalness) ||
+		!reader.ReadPod(out_obj.glass_blending) ||
+		!ReadString(reader, out_obj.particle_system) ||
+		!ReadObjRegionVector(reader, out_obj.regions) ||
+		!ReadIntVector(reader, out_obj.indices) ||
+		!ReadObjPointPool(reader, out_obj.geo_tri) ||
+		!ReadObjPointPool(reader, out_obj.geo_lines) ||
+		!ReadObjPointPool(reader, out_obj.geo_lights) ||
+		!ReadObjAnimationVector(reader, out_obj.animation) ||
+		!ReadObjManipVector(reader, out_obj.manips) ||
+		!ReadObjEmitterVector(reader, out_obj.emitters) ||
+		!ReadObjLodVector(reader, out_obj.lods) ||
+		!ReadFloatArray(reader, out_obj.xyz_min, 3) ||
+		!ReadFloatArray(reader, out_obj.xyz_max, 3) ||
+		!ReadDoubleArray(reader, out_obj.loadCenter_latlon, 2) ||
+		!reader.ReadPod(out_obj.loadCenter_texSize) ||
+		!reader.ReadPod(out_obj.loadCenter_size) ||
+		!reader.ReadPod(out_obj.fixed_heading) ||
+		!reader.ReadPod(out_obj.viewpoint_height) ||
+		!ReadString(reader, out_obj.description))
+		return false;
+
+	return reader.Done();
+}
+
+static std::vector<unsigned char> SerializePreparedTexture(const PreparedTextureImage& image)
+{
+	BlobWriter writer;
+	writer.WritePod(image.data_size);
+	writer.WritePod(image.width);
+	writer.WritePod(image.height);
+	writer.WritePod(image.channels);
+	writer.WritePod(image.level_count);
+	writer.WritePod(image.org_x);
+	writer.WritePod(image.org_y);
+	writer.WritePod(image.act_x);
+	writer.WritePod(image.act_y);
+	writer.WritePod(image.vis_x);
+	writer.WritePod(image.vis_y);
+	if (image.data_size > 0 && image.data != nullptr)
+		writer.WriteBytes(image.data, image.data_size);
+	return writer.data;
+}
+
+static bool DeserializePreparedTexture(const std::vector<unsigned char>& bytes, PreparedTextureImage& out_image)
+{
+	DestroyPreparedTextureImage(&out_image);
+	BlobReader reader(bytes.data(), bytes.data() + bytes.size());
+	if (!reader.ReadPod(out_image.data_size) ||
+		!reader.ReadPod(out_image.width) ||
+		!reader.ReadPod(out_image.height) ||
+		!reader.ReadPod(out_image.channels) ||
+		!reader.ReadPod(out_image.level_count) ||
+		!reader.ReadPod(out_image.org_x) ||
+		!reader.ReadPod(out_image.org_y) ||
+		!reader.ReadPod(out_image.act_x) ||
+		!reader.ReadPod(out_image.act_y) ||
+		!reader.ReadPod(out_image.vis_x) ||
+		!reader.ReadPod(out_image.vis_y))
+		return false;
+
+	if (out_image.data_size < 0)
+		return false;
+
+	if (out_image.data_size > 0)
+	{
+		out_image.data = reinterpret_cast<unsigned char *>(malloc(out_image.data_size));
+		if (out_image.data == nullptr)
+			return false;
+		if (!reader.ReadBytes(out_image.data, out_image.data_size))
+		{
+			DestroyPreparedTextureImage(&out_image);
+			return false;
+		}
+	}
+
+	return reader.Done();
+}
+
+static bool ExecSql(sqlite3 * db, const char * sql)
+{
+	return sqlite3_exec(db, sql, nullptr, nullptr, nullptr) == SQLITE_OK;
+}
+
+static sqlite3_int64 FileOffsetEnd(FILE * file)
+{
+#if IBM
+	_fseeki64(file, 0, SEEK_END);
+	return _ftelli64(file);
+#else
+	fseeko(file, 0, SEEK_END);
+	return ftello(file);
+#endif
+}
+
+}
+
+WED_ResourceCache& WED_ResourceCache::Get()
+{
+	static WED_ResourceCache cache;
+	return cache;
+}
+
+WED_ResourceCache::WED_ResourceCache() :
+	mEnabled(EnvFlagEnabledOrDefault("WED_RESOURCE_CACHE_V2", true)),
+	mInitAttempted(false),
+	mOpenOk(false),
+	mActivePackName(kPackFileName),
+	mDb(nullptr)
+{
+	const char * local_app_data = getenv("LOCALAPPDATA");
+	if (local_app_data && local_app_data[0] != '\0')
+		mRootPath = std::string(local_app_data) + DIR_STR "xptools" DIR_STR "resource-cache-v2";
+	else
+		mRootPath = GetCacheFolder() + DIR_STR "xptools" DIR_STR "resource-cache-v2";
+	mDbPath = mRootPath + DIR_STR "cache.db";
+	mPackDirPath = mRootPath + DIR_STR "packs";
+}
+
+WED_ResourceCache::~WED_ResourceCache()
+{
+	std::lock_guard<std::mutex> guard(mMutex);
+	CloseLocked();
+}
+
+bool WED_ResourceCache::Enabled() const
+{
+	return mEnabled;
+}
+
+std::string WED_ResourceCache::GetRootPath() const
+{
+	return mRootPath;
+}
+
+bool WED_ResourceCache::EnsureOpenLocked()
+{
+	if (!mEnabled)
+		return false;
+	if (mInitAttempted)
+		return mOpenOk;
+
+	mInitAttempted = true;
+	if (FILE_make_dir_exist(mPackDirPath.c_str()) != 0)
+		return false;
+
+	if (sqlite3_open(mDbPath.c_str(), &mDb) != SQLITE_OK)
+	{
+		if (mDb)
+			sqlite3_close(mDb);
+		mDb = nullptr;
+		return false;
+	}
+
+	ExecSql(mDb, "PRAGMA journal_mode=WAL;");
+	ExecSql(mDb, "PRAGMA synchronous=NORMAL;");
+	ExecSql(mDb, "PRAGMA temp_store=MEMORY;");
+	if (!ExecSql(mDb,
+		"CREATE TABLE IF NOT EXISTS artifacts ("
+		"cache_key TEXT PRIMARY KEY,"
+		"kind INTEGER NOT NULL,"
+		"schema_version INTEGER NOT NULL,"
+		"flags INTEGER NOT NULL,"
+		"source_path TEXT NOT NULL,"
+		"source_size INTEGER NOT NULL,"
+		"source_mtime INTEGER NOT NULL,"
+		"pack_name TEXT NOT NULL,"
+		"pack_offset INTEGER NOT NULL,"
+		"pack_size INTEGER NOT NULL,"
+		"created_at INTEGER NOT NULL,"
+		"last_access INTEGER NOT NULL,"
+		"hit_count INTEGER NOT NULL DEFAULT 0"
+		");"))
+	{
+		CloseLocked();
+		return false;
+	}
+
+	mOpenOk = true;
+	return true;
+}
+
+void WED_ResourceCache::CloseLocked()
+{
+	if (mDb != nullptr)
+	{
+		sqlite3_close(mDb);
+		mDb = nullptr;
+	}
+	mOpenOk = false;
+}
+
+WED_ResourceCache::SourceFingerprint WED_ResourceCache::MakeFingerprint(const std::string& source_path) const
+{
+	SourceFingerprint fp;
+	struct stat meta_data = { 0 };
+	if (FILE_get_file_meta_data(source_path, meta_data) != 0)
+		return fp;
+	fp.normalized_path = NormalizePathForKey(source_path);
+	fp.size = static_cast<long long>(meta_data.st_size);
+	fp.mtime = static_cast<long long>(meta_data.st_mtime);
+	fp.valid = true;
+	return fp;
+}
+
+std::string WED_ResourceCache::BuildCacheKey(ArtifactKind kind, const SourceFingerprint& fp, int flags, int schema_version) const
+{
+	std::string key_material = fp.normalized_path;
+	key_material += "|";
+	key_material += std::to_string(static_cast<int>(kind));
+	key_material += "|";
+	key_material += std::to_string(schema_version);
+	key_material += "|";
+	key_material += std::to_string(flags);
+	key_material += "|";
+	key_material += std::to_string(fp.size);
+	key_material += "|";
+	key_material += std::to_string(fp.mtime);
+	return HexU64(Fnv1a64(key_material));
+}
+
+bool WED_ResourceCache::LookupArtifactLocked(ArtifactKind kind, const std::string& cache_key, ArtifactRecord& out_record)
+{
+	if (!EnsureOpenLocked())
+		return false;
+
+	sqlite3_stmt * stmt = nullptr;
+	if (sqlite3_prepare_v2(mDb, "SELECT pack_name, pack_offset, pack_size FROM artifacts WHERE cache_key = ?1 AND kind = ?2;", -1, &stmt, nullptr) != SQLITE_OK)
+		return false;
+
+	sqlite3_bind_text(stmt, 1, cache_key.c_str(), -1, SQLITE_TRANSIENT);
+	sqlite3_bind_int(stmt, 2, static_cast<int>(kind));
+
+	const int step = sqlite3_step(stmt);
+	if (step != SQLITE_ROW)
+	{
+		sqlite3_finalize(stmt);
+		return false;
+	}
+
+	const unsigned char * pack_name_text = sqlite3_column_text(stmt, 0);
+	out_record.pack_name = pack_name_text ? reinterpret_cast<const char *>(pack_name_text) : "";
+	out_record.offset = sqlite3_column_int64(stmt, 1);
+	out_record.size = sqlite3_column_int64(stmt, 2);
+	out_record.valid = true;
+	sqlite3_finalize(stmt);
+
+	sqlite3_stmt * touch = nullptr;
+	if (sqlite3_prepare_v2(mDb, "UPDATE artifacts SET last_access = ?2, hit_count = hit_count + 1 WHERE cache_key = ?1;", -1, &touch, nullptr) == SQLITE_OK)
+	{
+		sqlite3_bind_text(touch, 1, cache_key.c_str(), -1, SQLITE_TRANSIENT);
+		sqlite3_bind_int64(touch, 2, NowUnixSeconds());
+		sqlite3_step(touch);
+		sqlite3_finalize(touch);
+	}
+
+	return true;
+}
+
+bool WED_ResourceCache::ReadArtifactLocked(ArtifactKind kind, const ArtifactRecord& record, std::vector<unsigned char>& out_payload)
+{
+	if (!record.valid)
+		return false;
+
+	const std::string pack_path = mPackDirPath + DIR_STR + record.pack_name;
+	MFMemFile * file = MemFile_Open(pack_path.c_str());
+	if (file == nullptr)
+		return false;
+
+	const char * begin = MemFile_GetBegin(file);
+	const char * end = MemFile_GetEnd(file);
+	const long long available = static_cast<long long>(end - begin);
+	if (record.offset < 0 || record.size < 0 || record.offset + record.size > available)
+	{
+		MemFile_Close(file);
+		return false;
+	}
+
+	const unsigned char * entry_begin = reinterpret_cast<const unsigned char *>(begin + record.offset);
+	const unsigned char * entry_end = reinterpret_cast<const unsigned char *>(begin + record.offset + record.size);
+	BlobReader reader(entry_begin, entry_end);
+	PackEntryHeader header = { 0 };
+	if (!reader.ReadPod(header) ||
+		header.magic != kPackMagic ||
+		header.kind != static_cast<unsigned int>(kind) ||
+		header.payload_size > static_cast<unsigned long long>(entry_end - reader.cur))
+	{
+		MemFile_Close(file);
+		return false;
+	}
+
+	out_payload.resize(static_cast<size_t>(header.payload_size));
+	if (header.payload_size > 0)
+		memcpy(out_payload.data(), reader.cur, static_cast<size_t>(header.payload_size));
+	MemFile_Close(file);
+	return true;
+}
+
+void WED_ResourceCache::StoreArtifactLocked(ArtifactKind kind, const SourceFingerprint& fp, int flags, int schema_version, const std::vector<unsigned char>& payload)
+{
+	if (!EnsureOpenLocked())
+		return;
+
+	const std::string pack_path = mPackDirPath + DIR_STR + mActivePackName;
+	FILE * file = fopen(pack_path.c_str(), "ab");
+	if (file == nullptr)
+		return;
+
+	PackEntryHeader header = { 0 };
+	header.magic = kPackMagic;
+	header.kind = static_cast<unsigned int>(kind);
+	header.payload_size = static_cast<unsigned long long>(payload.size());
+	const sqlite3_int64 offset = FileOffsetEnd(file);
+
+	const bool wrote_header = fwrite(&header, sizeof(header), 1, file) == 1;
+	const bool wrote_payload = payload.empty() || fwrite(payload.data(), 1, payload.size(), file) == payload.size();
+	fclose(file);
+	if (!wrote_header || !wrote_payload)
+		return;
+
+	const std::string cache_key = BuildCacheKey(kind, fp, flags, schema_version);
+	sqlite3_stmt * stmt = nullptr;
+	if (sqlite3_prepare_v2(
+		mDb,
+		"INSERT OR REPLACE INTO artifacts (cache_key, kind, schema_version, flags, source_path, source_size, source_mtime, pack_name, pack_offset, pack_size, created_at, last_access, hit_count) "
+		"VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?11, 0);",
+		-1,
+		&stmt,
+		nullptr) != SQLITE_OK)
+	{
+		return;
+	}
+
+	const long long now = NowUnixSeconds();
+	sqlite3_bind_text(stmt, 1, cache_key.c_str(), -1, SQLITE_TRANSIENT);
+	sqlite3_bind_int(stmt, 2, static_cast<int>(kind));
+	sqlite3_bind_int(stmt, 3, schema_version);
+	sqlite3_bind_int(stmt, 4, flags);
+	sqlite3_bind_text(stmt, 5, fp.normalized_path.c_str(), -1, SQLITE_TRANSIENT);
+	sqlite3_bind_int64(stmt, 6, fp.size);
+	sqlite3_bind_int64(stmt, 7, fp.mtime);
+	sqlite3_bind_text(stmt, 8, mActivePackName.c_str(), -1, SQLITE_TRANSIENT);
+	sqlite3_bind_int64(stmt, 9, offset);
+	sqlite3_bind_int64(stmt, 10, static_cast<sqlite3_int64>(sizeof(header) + payload.size()));
+	sqlite3_bind_int64(stmt, 11, now);
+	sqlite3_step(stmt);
+	sqlite3_finalize(stmt);
+}
+
+bool WED_ResourceCache::LoadObjMeta(const std::string& source_path, WED_ResourceCacheObjMeta& out_meta)
+{
+	std::lock_guard<std::mutex> guard(mMutex);
+	const SourceFingerprint fp = MakeFingerprint(source_path);
+	if (!fp.valid)
+		return false;
+	const std::string cache_key = BuildCacheKey(artifact_ObjMeta, fp, 0, kObjMetaSchemaVersion);
+	ArtifactRecord record;
+	if (!LookupArtifactLocked(artifact_ObjMeta, cache_key, record))
+		return false;
+	std::vector<unsigned char> payload;
+	return ReadArtifactLocked(artifact_ObjMeta, record, payload) && DeserializeObjMeta(payload, out_meta);
+}
+
+void WED_ResourceCache::StoreObjMeta(const std::string& source_path, const WED_ResourceCacheObjMeta& meta)
+{
+	std::lock_guard<std::mutex> guard(mMutex);
+	const SourceFingerprint fp = MakeFingerprint(source_path);
+	if (!fp.valid)
+		return;
+	StoreArtifactLocked(artifact_ObjMeta, fp, 0, kObjMetaSchemaVersion, SerializeObjMeta(meta));
+}
+
+bool WED_ResourceCache::LoadObjGeom(const std::string& source_path, XObj8& out_obj)
+{
+	std::lock_guard<std::mutex> guard(mMutex);
+	const SourceFingerprint fp = MakeFingerprint(source_path);
+	if (!fp.valid)
+		return false;
+	const std::string cache_key = BuildCacheKey(artifact_ObjGeom, fp, 0, kObjGeomSchemaVersion);
+	ArtifactRecord record;
+	if (!LookupArtifactLocked(artifact_ObjGeom, cache_key, record))
+		return false;
+	std::vector<unsigned char> payload;
+	return ReadArtifactLocked(artifact_ObjGeom, record, payload) && DeserializeObjGeom(payload, out_obj);
+}
+
+void WED_ResourceCache::StoreObjGeom(const std::string& source_path, const XObj8& obj)
+{
+	std::lock_guard<std::mutex> guard(mMutex);
+	const SourceFingerprint fp = MakeFingerprint(source_path);
+	if (!fp.valid)
+		return;
+	StoreArtifactLocked(artifact_ObjGeom, fp, 0, kObjGeomSchemaVersion, SerializeObjGeom(obj));
+	StoreArtifactLocked(artifact_ObjMeta, fp, 0, kObjMetaSchemaVersion, SerializeObjMeta(ExtractObjMeta(obj)));
+}
+
+bool WED_ResourceCache::LoadPreparedTexture(const std::string& source_path, int flags, PreparedTextureImage& out_image)
+{
+	std::lock_guard<std::mutex> guard(mMutex);
+	const SourceFingerprint fp = MakeFingerprint(source_path);
+	if (!fp.valid)
+		return false;
+	const std::string cache_key = BuildCacheKey(artifact_TexPrepared, fp, flags, kTexPreparedSchemaVersion);
+	ArtifactRecord record;
+	if (!LookupArtifactLocked(artifact_TexPrepared, cache_key, record))
+		return false;
+	std::vector<unsigned char> payload;
+	return ReadArtifactLocked(artifact_TexPrepared, record, payload) && DeserializePreparedTexture(payload, out_image);
+}
+
+void WED_ResourceCache::StorePreparedTexture(const std::string& source_path, int flags, const PreparedTextureImage& image)
+{
+	std::lock_guard<std::mutex> guard(mMutex);
+	const SourceFingerprint fp = MakeFingerprint(source_path);
+	if (!fp.valid)
+		return;
+	StoreArtifactLocked(artifact_TexPrepared, fp, flags, kTexPreparedSchemaVersion, SerializePreparedTexture(image));
+}

--- a/src/WEDCore/WED_ResourceCache.h
+++ b/src/WEDCore/WED_ResourceCache.h
@@ -18,6 +18,13 @@ struct WED_ResourceCacheObjMeta {
 	float xyz_max[3] = { 0.0f, 0.0f, 0.0f };
 };
 
+struct WED_ResourceCachePreparedTextureLoadPerf {
+	double lookup_seconds = 0.0;
+	double read_seconds = 0.0;
+	double deserialize_seconds = 0.0;
+	double total_seconds = 0.0;
+};
+
 class WED_ResourceCache {
 public:
 	static WED_ResourceCache& Get();
@@ -31,8 +38,10 @@ public:
 	bool LoadObjGeom(const std::string& source_path, XObj8& out_obj);
 	void StoreObjGeom(const std::string& source_path, const XObj8& obj);
 
-	bool LoadPreparedTexture(const std::string& source_path, int flags, PreparedTextureImage& out_image);
+	bool LoadPreparedTexture(const std::string& source_path, int flags, PreparedTextureImage& out_image, WED_ResourceCachePreparedTextureLoadPerf * out_perf = nullptr);
 	void StorePreparedTexture(const std::string& source_path, int flags, const PreparedTextureImage& image);
+	bool LoadCompressedTexture(const std::string& source_path, int flags, CompressedTextureImage& out_image, WED_ResourceCachePreparedTextureLoadPerf * out_perf = nullptr);
+	void StoreCompressedTexture(const std::string& source_path, int flags, const CompressedTextureImage& image);
 
 private:
 	WED_ResourceCache();
@@ -43,7 +52,8 @@ private:
 	enum ArtifactKind {
 		artifact_ObjMeta = 1,
 		artifact_ObjGeom = 2,
-		artifact_TexPrepared = 3
+		artifact_TexPrepared = 3,
+		artifact_TexCompressed = 4
 	};
 
 	struct SourceFingerprint {

--- a/src/WEDCore/WED_ResourceCache.h
+++ b/src/WEDCore/WED_ResourceCache.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026
+ */
+
+#ifndef WED_ResourceCache_H
+#define WED_ResourceCache_H
+
+#include "TexUtils.h"
+#include "XObjDefs.h"
+#include <mutex>
+#include <string>
+#include <vector>
+
+struct WED_ResourceCacheObjMeta {
+	float fixed_heading = -1.0f;
+	float viewpoint_height = -1.0f;
+	float xyz_min[3] = { 0.0f, 0.0f, 0.0f };
+	float xyz_max[3] = { 0.0f, 0.0f, 0.0f };
+};
+
+class WED_ResourceCache {
+public:
+	static WED_ResourceCache& Get();
+
+	bool Enabled() const;
+	std::string GetRootPath() const;
+
+	bool LoadObjMeta(const std::string& source_path, WED_ResourceCacheObjMeta& out_meta);
+	void StoreObjMeta(const std::string& source_path, const WED_ResourceCacheObjMeta& meta);
+
+	bool LoadObjGeom(const std::string& source_path, XObj8& out_obj);
+	void StoreObjGeom(const std::string& source_path, const XObj8& obj);
+
+	bool LoadPreparedTexture(const std::string& source_path, int flags, PreparedTextureImage& out_image);
+	void StorePreparedTexture(const std::string& source_path, int flags, const PreparedTextureImage& image);
+
+private:
+	WED_ResourceCache();
+	~WED_ResourceCache();
+	WED_ResourceCache(const WED_ResourceCache&) = delete;
+	WED_ResourceCache& operator=(const WED_ResourceCache&) = delete;
+
+	enum ArtifactKind {
+		artifact_ObjMeta = 1,
+		artifact_ObjGeom = 2,
+		artifact_TexPrepared = 3
+	};
+
+	struct SourceFingerprint {
+		std::string normalized_path;
+		long long size = 0;
+		long long mtime = 0;
+		bool valid = false;
+	};
+
+	struct ArtifactRecord {
+		std::string pack_name;
+		long long offset = 0;
+		long long size = 0;
+		bool valid = false;
+	};
+
+	bool EnsureOpenLocked();
+	void CloseLocked();
+	SourceFingerprint MakeFingerprint(const std::string& source_path) const;
+	std::string BuildCacheKey(ArtifactKind kind, const SourceFingerprint& fp, int flags, int schema_version) const;
+	bool LookupArtifactLocked(ArtifactKind kind, const std::string& cache_key, ArtifactRecord& out_record);
+	bool ReadArtifactLocked(ArtifactKind kind, const ArtifactRecord& record, std::vector<unsigned char>& out_payload);
+	void StoreArtifactLocked(ArtifactKind kind, const SourceFingerprint& fp, int flags, int schema_version, const std::vector<unsigned char>& payload);
+
+	mutable std::mutex mMutex;
+	bool mEnabled;
+	bool mInitAttempted;
+	bool mOpenOk;
+	std::string mRootPath;
+	std::string mDbPath;
+	std::string mPackDirPath;
+	std::string mActivePackName;
+	struct sqlite3 * mDb;
+};
+
+#endif

--- a/src/WEDCore/WED_ResourceCache.h
+++ b/src/WEDCore/WED_ResourceCache.h
@@ -44,6 +44,8 @@ public:
 	void StorePreparedTexture(const std::string& source_path, int flags, const PreparedTextureImage& image);
 	bool LoadCompressedTexture(const std::string& source_path, int flags, CompressedTextureImage& out_image, WED_ResourceCachePreparedTextureLoadPerf * out_perf = nullptr);
 	void StoreCompressedTexture(const std::string& source_path, int flags, const CompressedTextureImage& image);
+	bool LoadNavaidIndex(const std::string& source_signature, std::vector<unsigned char>& out_payload);
+	void StoreNavaidIndex(const std::string& source_signature, const std::vector<unsigned char>& payload);
 
 private:
 	WED_ResourceCache();
@@ -55,7 +57,8 @@ private:
 		artifact_ObjMeta = 1,
 		artifact_ObjGeom = 2,
 		artifact_TexPrepared = 3,
-		artifact_TexCompressed = 4
+		artifact_TexCompressed = 4,
+		artifact_NavaidIndex = 5
 	};
 
 	struct SourceFingerprint {
@@ -85,6 +88,7 @@ private:
 	bool EnsureSchemaLocked();
 	bool ResetStorageLocked();
 	SourceFingerprint MakeFingerprint(const std::string& source_path) const;
+	SourceFingerprint MakeVirtualFingerprint(const std::string& source_identity) const;
 	std::string BuildCacheKey(ArtifactKind kind, const SourceFingerprint& fp, int flags, int schema_version) const;
 	bool LookupArtifactLocked(ArtifactKind kind, const std::string& cache_key, ArtifactRecord& out_record);
 	bool ReadArtifactLocked(ArtifactKind kind, const ArtifactRecord& record, std::vector<unsigned char>& out_payload);

--- a/src/WEDCore/WED_ResourceCache.h
+++ b/src/WEDCore/WED_ResourceCache.h
@@ -31,6 +31,8 @@ public:
 
 	bool Enabled() const;
 	std::string GetRootPath() const;
+	void SetEnabled(bool enabled);
+	bool Clear();
 
 	bool LoadObjMeta(const std::string& source_path, WED_ResourceCacheObjMeta& out_meta);
 	void StoreObjMeta(const std::string& source_path, const WED_ResourceCacheObjMeta& meta);
@@ -70,13 +72,32 @@ private:
 		bool valid = false;
 	};
 
+	struct SegmentRecord {
+		std::string pack_name;
+		long long sequence = 0;
+		long long total_bytes = 0;
+		bool sealed = false;
+		bool valid = false;
+	};
+
 	bool EnsureOpenLocked();
 	void CloseLocked();
+	bool EnsureSchemaLocked();
+	bool ResetStorageLocked();
 	SourceFingerprint MakeFingerprint(const std::string& source_path) const;
 	std::string BuildCacheKey(ArtifactKind kind, const SourceFingerprint& fp, int flags, int schema_version) const;
 	bool LookupArtifactLocked(ArtifactKind kind, const std::string& cache_key, ArtifactRecord& out_record);
 	bool ReadArtifactLocked(ArtifactKind kind, const ArtifactRecord& record, std::vector<unsigned char>& out_payload);
 	void StoreArtifactLocked(ArtifactKind kind, const SourceFingerprint& fp, int flags, int schema_version, const std::vector<unsigned char>& payload);
+	bool EnsureCapacityForWriteLocked(long long entry_size);
+	bool EnsureActivePackLocked();
+	bool CreateNewActivePackLocked();
+	void SealActivePackLocked();
+	bool FindOldestSealedPackLocked(SegmentRecord& out_record);
+	bool DeletePackLocked(const SegmentRecord& record);
+	long long QueryTotalSegmentBytesLocked() const;
+	long long ComputeEffectiveHardCapBytesLocked(long long current_total_bytes) const;
+	long long ComputePruneTargetBytesLocked(long long effective_hard_cap_bytes) const;
 
 	mutable std::mutex mMutex;
 	bool mEnabled;
@@ -86,6 +107,8 @@ private:
 	std::string mDbPath;
 	std::string mPackDirPath;
 	std::string mActivePackName;
+	long long mActivePackSize;
+	long long mNextPackSequence;
 	struct sqlite3 * mDb;
 };
 

--- a/src/WEDCore/WED_ResourceMgr.cpp
+++ b/src/WEDCore/WED_ResourceMgr.cpp
@@ -28,6 +28,7 @@
 #include "WED_LibraryMgr.h"
 #include "WED_Globals.h"
 #include "WED_Version.h"
+#include "WED_ResourceCache.h"
 
 #include "MemFileUtils.h"
 #include "XObjReadWrite.h"
@@ -36,6 +37,7 @@
 #include "CompGeomDefs2.h"
 #include "MathUtils.h"
 #include "BitmapUtils.h"
+#include <utility>
 
 #include "DEMDefs.h"
 #include "WED_OrthoExport.h"
@@ -176,12 +178,20 @@ bool	WED_ResourceMgr::GetDem(const string& path, dem_info_t const*& info)
 
 XObj8 * WED_ResourceMgr::LoadObj(const string& abspath)
 {
-	XObj8 * new_obj = new XObj8;
-	if(!XObj8Read(abspath.c_str(),*new_obj))
+	XObj8 * new_obj = nullptr;
+	XObj8 cached_obj;
+	if (WED_ResourceCache::Get().LoadObjGeom(abspath, cached_obj))
 	{
-		delete new_obj;
-		return nullptr;
+		new_obj = new XObj8(std::move(cached_obj));
 	}
+	else
+	{
+		new_obj = new XObj8;
+		if(!XObj8Read(abspath.c_str(),*new_obj))
+		{
+			delete new_obj;
+			return nullptr;
+		}
 	for (auto& l : new_obj->lods)  // balance begin/end_annimation in broken assets to fix display artefacts due to imbalanced glPush/PopMatrix()
 	{
 		int num_anims = 0;
@@ -208,6 +218,8 @@ XObj8 * WED_ResourceMgr::LoadObj(const string& abspath)
 	}
 	else
 		new_obj->texture_draped = new_obj->texture;
+		WED_ResourceCache::Get().StoreObjGeom(abspath, *new_obj);
+	}
 
 	return new_obj;
 }

--- a/src/WEDCore/WED_TexMgr.cpp
+++ b/src/WEDCore/WED_TexMgr.cpp
@@ -29,7 +29,9 @@
 #include "TexUtils.h"
 #include "WED_ResourceCache.h"
 #include "WED_PackageMgr.h"
+#include <chrono>
 #include <cctype>
+#include <cstdlib>
 
 #if APL
 	#include <OpenGL/gl.h>
@@ -38,6 +40,40 @@
 #endif
 
 namespace {
+
+static bool PerfOpenAnalysisEnabled()
+{
+	static const bool enabled = []() {
+		const char * raw_value = getenv("WED_PERF_OPEN_ANALYSIS");
+		if (raw_value == nullptr || raw_value[0] == '\0')
+			return false;
+
+		string value(raw_value);
+		for (char& ch : value)
+			ch = static_cast<char>(tolower(static_cast<unsigned char>(ch)));
+
+		return value != "0" && value != "false" && value != "off" && value != "no";
+	}();
+	return enabled;
+}
+
+static bool EnvFlagEnabled(const char * name)
+{
+	const char * raw_value = getenv(name);
+	if (raw_value == nullptr || raw_value[0] == '\0')
+		return false;
+
+	string value(raw_value);
+	for (char& ch : value)
+		ch = static_cast<char>(tolower(static_cast<unsigned char>(ch)));
+
+	return value != "0" && value != "false" && value != "off" && value != "no";
+}
+
+static int EffectiveTextureFlags(int flags)
+{
+	return EnvFlagEnabled("WED_PERF_DISABLE_TEX_COMPRESS_OK") ? (flags & ~tex_Compress_Ok) : flags;
+}
 
 static bool IsDirectCompressedTexturePath(const string& path)
 {
@@ -113,8 +149,11 @@ void		WED_TexMgr::GetTexInfo(
 
 WED_TexMgr::TexInfo *	WED_TexMgr::LoadTexture(const char * path, bool is_absolute, int flags)
 {
+	const bool perf_enabled = PerfOpenAnalysisEnabled();
+	const auto perf_begin = perf_enabled ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
 	string fpath(is_absolute ? path : gPackageMgr->ComputePath(mPackage, path));
 	TexInfo * inf = NULL;
+	const char * perf_mode = "source_prepare";
 
 	GLuint tn;
 	glGenTextures(1,&tn);
@@ -125,6 +164,7 @@ WED_TexMgr::TexInfo *	WED_TexMgr::LoadTexture(const char * path, bool is_absolut
 	{
 		if (strncmp(c, "DDS ",4) == 0)
 		{
+			perf_mode = "direct_compressed";
 			fseek(file, 0, SEEK_END);
 			int fileLength = ftell(file);
 			fseek(file, 0, SEEK_SET);
@@ -150,6 +190,7 @@ WED_TexMgr::TexInfo *	WED_TexMgr::LoadTexture(const char * path, bool is_absolut
 #if LOAD_KTX2_DIRECT
 		else if (strncmp(c, "\253KTX 20\273", 8) == 0)
 		{
+			perf_mode = "direct_compressed";
 			fseek(file, 0, SEEK_END);
 			int fileLength = ftell(file);
 			fseek(file, 0, SEEK_SET);
@@ -185,46 +226,138 @@ WED_TexMgr::TexInfo *	WED_TexMgr::LoadTexture(const char * path, bool is_absolut
 	{
 		EnsureTextureUploadCapsInitializedOnDrawThread();
 		PreparedTextureImage prepared;
+		CompressedTextureImage compressed;
+		PreparedTextureUploadPerf upload_perf;
+		WED_ResourceCachePreparedTextureLoadPerf cache_perf;
 		int siz_x = 0;
 		int siz_y = 0;
 		float s = 1.0f;
 		float t = 1.0f;
 		bool loaded = false;
-		if (!IsDirectCompressedTexturePath(fpath) && WED_ResourceCache::Get().LoadPreparedTexture(fpath, flags, prepared))
+		const int effective_flags = EffectiveTextureFlags(flags);
+		const bool allow_compressed_cache = !IsDirectCompressedTexturePath(fpath) && ((effective_flags & tex_Compress_Ok) != 0);
+		auto maybe_store_compressed_cache = [&]() {
+			if (!allow_compressed_cache || upload_perf.compress_ok == 0)
+				return;
+
+			CompressedTextureImage captured;
+			if (CaptureCompressedTextureFromBoundTexture(prepared, &captured))
+				WED_ResourceCache::Get().StoreCompressedTexture(fpath, flags, captured);
+			DestroyCompressedTextureImage(&captured);
+		};
+
+		if (allow_compressed_cache && WED_ResourceCache::Get().LoadCompressedTexture(fpath, flags, compressed, &cache_perf))
 		{
-			loaded = LoadTextureFromPreparedImage(prepared, tn, flags);
+			loaded = LoadTextureFromCompressedImage(compressed, tn, flags, &upload_perf);
 			if (loaded)
 			{
-				siz_x = prepared.act_x;
-				siz_y = prepared.act_y;
-				s = prepared.act_x > 0 ? static_cast<float>(prepared.vis_x) / static_cast<float>(prepared.act_x) : 1.0f;
-				t = prepared.act_y > 0 ? static_cast<float>(prepared.vis_y) / static_cast<float>(prepared.act_y) : 1.0f;
+				perf_mode = "compressed_cache_hit";
+				siz_x = compressed.act_x;
+				siz_y = compressed.act_y;
+				s = compressed.act_x > 0 ? static_cast<float>(compressed.vis_x) / static_cast<float>(compressed.act_x) : 1.0f;
+				t = compressed.act_y > 0 ? static_cast<float>(compressed.vis_y) / static_cast<float>(compressed.act_y) : 1.0f;
+				if (perf_enabled)
+				{
+					LOG_MSG(
+						"I/Perf CompressedTextureHot path=%s compress_ok=%d cache_lookup=%.3lf s cache_read=%.3lf s cache_deserialize=%.3lf s cache_total=%.3lf s upload_gl=%.3lf s upload_configure=%.3lf s upload_total=%.3lf s bytes=%d levels=%d size=%dx%d internal_format=0x%X\n",
+						fpath.c_str(),
+						upload_perf.compress_ok,
+						cache_perf.lookup_seconds,
+						cache_perf.read_seconds,
+						cache_perf.deserialize_seconds,
+						cache_perf.total_seconds,
+						upload_perf.upload_seconds,
+						upload_perf.configure_seconds,
+						upload_perf.total_seconds,
+						upload_perf.data_size,
+						upload_perf.level_count,
+						upload_perf.width,
+						upload_perf.height,
+						compressed.internal_format);
+				}
 			}
+			DestroyCompressedTextureImage(&compressed);
 		}
-		else
-		{
-			ImageInfo im = { 0 };
-			if (LoadBitmapFromAnyFile(fpath.c_str(), &im) == 0)
-			{
-				if (PrepareTextureImageForUpload(im, flags, &prepared))
-				{
-					loaded = LoadTextureFromPreparedImage(prepared, tn, flags);
-					if (loaded)
-					{
-						siz_x = prepared.act_x;
-						siz_y = prepared.act_y;
-						s = prepared.act_x > 0 ? static_cast<float>(prepared.vis_x) / static_cast<float>(prepared.act_x) : 1.0f;
-						t = prepared.act_y > 0 ? static_cast<float>(prepared.vis_y) / static_cast<float>(prepared.act_y) : 1.0f;
-						WED_ResourceCache::Get().StorePreparedTexture(fpath, flags, prepared);
-					}
-				}
-				else
-				{
-					loaded = LoadTextureFromImage(im, tn, flags, &siz_x, &siz_y, &s, &t);
-				}
 
-				if (im.data != nullptr)
-					DestroyBitmap(&im);
+		if (!loaded)
+		{
+			if (!IsDirectCompressedTexturePath(fpath) && WED_ResourceCache::Get().LoadPreparedTexture(fpath, flags, prepared, &cache_perf))
+			{
+				perf_mode = "prepared_cache_hit";
+				loaded = LoadTextureFromPreparedImage(prepared, tn, flags, &upload_perf);
+				if (loaded)
+				{
+					siz_x = prepared.act_x;
+					siz_y = prepared.act_y;
+					s = prepared.act_x > 0 ? static_cast<float>(prepared.vis_x) / static_cast<float>(prepared.act_x) : 1.0f;
+					t = prepared.act_y > 0 ? static_cast<float>(prepared.vis_y) / static_cast<float>(prepared.act_y) : 1.0f;
+					maybe_store_compressed_cache();
+				}
+				if (perf_enabled)
+				{
+					LOG_MSG(
+						"I/Perf PreparedTextureHot path=%s compress_ok=%d cache_lookup=%.3lf s cache_read=%.3lf s cache_deserialize=%.3lf s cache_total=%.3lf s upload_convert=%.3lf s upload_gl=%.3lf s upload_configure=%.3lf s upload_total=%.3lf s bytes=%d levels=%d size=%dx%d channels=%d\n",
+						fpath.c_str(),
+						upload_perf.compress_ok,
+						cache_perf.lookup_seconds,
+						cache_perf.read_seconds,
+						cache_perf.deserialize_seconds,
+						cache_perf.total_seconds,
+						upload_perf.convert_seconds,
+						upload_perf.upload_seconds,
+						upload_perf.configure_seconds,
+						upload_perf.total_seconds,
+						upload_perf.data_size,
+						upload_perf.level_count,
+						upload_perf.width,
+						upload_perf.height,
+						upload_perf.channels);
+				}
+			}
+
+			if (!loaded)
+			{
+				ImageInfo im = { 0 };
+				if (LoadBitmapFromAnyFile(fpath.c_str(), &im) == 0)
+				{
+					if (PrepareTextureImageForUpload(im, flags, &prepared))
+					{
+						loaded = LoadTextureFromPreparedImage(prepared, tn, flags, &upload_perf);
+						if (loaded)
+						{
+							siz_x = prepared.act_x;
+							siz_y = prepared.act_y;
+							s = prepared.act_x > 0 ? static_cast<float>(prepared.vis_x) / static_cast<float>(prepared.act_x) : 1.0f;
+							t = prepared.act_y > 0 ? static_cast<float>(prepared.vis_y) / static_cast<float>(prepared.act_y) : 1.0f;
+							WED_ResourceCache::Get().StorePreparedTexture(fpath, flags, prepared);
+							maybe_store_compressed_cache();
+						}
+						if (perf_enabled)
+						{
+							LOG_MSG(
+								"I/Perf PreparedTextureSource path=%s compress_ok=%d upload_convert=%.3lf s upload_gl=%.3lf s upload_configure=%.3lf s upload_total=%.3lf s bytes=%d levels=%d size=%dx%d channels=%d\n",
+								fpath.c_str(),
+								upload_perf.compress_ok,
+								upload_perf.convert_seconds,
+								upload_perf.upload_seconds,
+								upload_perf.configure_seconds,
+								upload_perf.total_seconds,
+								upload_perf.data_size,
+								upload_perf.level_count,
+								upload_perf.width,
+								upload_perf.height,
+								upload_perf.channels);
+						}
+					}
+					else
+					{
+						perf_mode = "source_direct_fallback";
+						loaded = LoadTextureFromImage(im, tn, flags, &siz_x, &siz_y, &s, &t);
+					}
+
+					if (im.data != nullptr)
+						DestroyBitmap(&im);
+				}
 			}
 		}
 		if (loaded)
@@ -259,6 +392,11 @@ WED_TexMgr::TexInfo *	WED_TexMgr::LoadTexture(const char * path, bool is_absolut
 #if !NEW_TEX_LOAD_STRATEGY
 		DestroyBitmap(&im);
 #endif
+	}
+	if (perf_enabled)
+	{
+		const double elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - perf_begin).count();
+		LOG_MSG("I/Perf LoadTexture mode=%s path=%s elapsed=%.3lf s\n", perf_mode, fpath.c_str(), elapsed);
 	}
 	return inf;
 }

--- a/src/WEDCore/WED_TexMgr.cpp
+++ b/src/WEDCore/WED_TexMgr.cpp
@@ -24,18 +24,33 @@
 #define NEW_TEX_LOAD_STRATEGY 1
 
 #include "WED_TexMgr.h"
-#if !NEW_TEX_LOAD_STRATEGY
-	#include "BitmapUtils.h"
-#endif
+#include "BitmapUtils.h"
 #include "MemFileUtils.h"
 #include "TexUtils.h"
+#include "WED_ResourceCache.h"
 #include "WED_PackageMgr.h"
+#include <cctype>
 
 #if APL
 	#include <OpenGL/gl.h>
 #else
 	#include <GL/gl.h>
 #endif
+
+namespace {
+
+static bool IsDirectCompressedTexturePath(const string& path)
+{
+	string lowered(path);
+	for (char& ch : lowered)
+		ch = static_cast<char>(tolower(static_cast<unsigned char>(ch)));
+
+	return lowered.size() >= 4 && (
+		lowered.rfind(".dds") == lowered.size() - 4 ||
+		lowered.rfind(".ktx2") == lowered.size() - 5);
+}
+
+}
 
 WED_TexMgr::WED_TexMgr(const string& package) : mPackage(package)
 {
@@ -168,9 +183,51 @@ WED_TexMgr::TexInfo *	WED_TexMgr::LoadTexture(const char * path, bool is_absolut
 #if NEW_TEX_LOAD_STRATEGY
 	// auto-detection of file type, basic on file content, only
 	{
-		int siz_x, siz_y;
-		float s,t;
-		if (LoadTextureFromFile(fpath.c_str(), tn, flags, &siz_x, &siz_y, &s,&t))
+		EnsureTextureUploadCapsInitializedOnDrawThread();
+		PreparedTextureImage prepared;
+		int siz_x = 0;
+		int siz_y = 0;
+		float s = 1.0f;
+		float t = 1.0f;
+		bool loaded = false;
+		if (!IsDirectCompressedTexturePath(fpath) && WED_ResourceCache::Get().LoadPreparedTexture(fpath, flags, prepared))
+		{
+			loaded = LoadTextureFromPreparedImage(prepared, tn, flags);
+			if (loaded)
+			{
+				siz_x = prepared.act_x;
+				siz_y = prepared.act_y;
+				s = prepared.act_x > 0 ? static_cast<float>(prepared.vis_x) / static_cast<float>(prepared.act_x) : 1.0f;
+				t = prepared.act_y > 0 ? static_cast<float>(prepared.vis_y) / static_cast<float>(prepared.act_y) : 1.0f;
+			}
+		}
+		else
+		{
+			ImageInfo im = { 0 };
+			if (LoadBitmapFromAnyFile(fpath.c_str(), &im) == 0)
+			{
+				if (PrepareTextureImageForUpload(im, flags, &prepared))
+				{
+					loaded = LoadTextureFromPreparedImage(prepared, tn, flags);
+					if (loaded)
+					{
+						siz_x = prepared.act_x;
+						siz_y = prepared.act_y;
+						s = prepared.act_x > 0 ? static_cast<float>(prepared.vis_x) / static_cast<float>(prepared.act_x) : 1.0f;
+						t = prepared.act_y > 0 ? static_cast<float>(prepared.vis_y) / static_cast<float>(prepared.act_y) : 1.0f;
+						WED_ResourceCache::Get().StorePreparedTexture(fpath, flags, prepared);
+					}
+				}
+				else
+				{
+					loaded = LoadTextureFromImage(im, tn, flags, &siz_x, &siz_y, &s, &t);
+				}
+
+				if (im.data != nullptr)
+					DestroyBitmap(&im);
+			}
+		}
+		if (loaded)
 #else
 	// loading based on file name suffix. With this method we preserve awareness of original image size.
 	// But with openGL 3.0 as new minimum requirement - all GPU's have to support non-power-2 textures,
@@ -186,8 +243,8 @@ WED_TexMgr::TexInfo *	WED_TexMgr::LoadTexture(const char * path, bool is_absolut
 			inf = new TexInfo;
 			inf->tex_id = tn;
 #if NEW_TEX_LOAD_STRATEGY
-			inf->org_x = siz_x;
-			inf->org_y = siz_y;
+			inf->org_x = prepared.org_x > 0 ? prepared.org_x : siz_x;
+			inf->org_y = prepared.org_y > 0 ? prepared.org_y : siz_y;
 #else
 			inf->org_x = im.width;
 			inf->org_y = im.height;
@@ -198,6 +255,7 @@ WED_TexMgr::TexInfo *	WED_TexMgr::LoadTexture(const char * path, bool is_absolut
 			inf->vis_y = (float) siz_y * t;
 			mTexes[path] = inf;
 		}
+		DestroyPreparedTextureImage(&prepared);
 #if !NEW_TEX_LOAD_STRATEGY
 		DestroyBitmap(&im);
 #endif

--- a/src/WEDMap/WED_NavaidLayer.cpp
+++ b/src/WEDMap/WED_NavaidLayer.cpp
@@ -32,9 +32,14 @@
 #include "WED_Colors.h"
 #include "WED_MapZoomerNew.h"
 #include "WED_PackageMgr.h"
+#include "WED_ResourceCache.h"
+#include "FileUtils.h"
 #include "MemFileUtils.h"
 #include "PlatformUtils.h"
 #include "GISUtils.h"
+
+#include <cstring>
+#include <utility>
 
 #if APL
 	#include <OpenGL/gl.h>
@@ -52,6 +57,232 @@
 #define COMPARE_GW_TO_APTDAT  0       // loads list of all airports from gateway and comares it to local apt.dat data
 
 #define NAVAID_EXTRA_RANGE  GLOBAL_WED_ART_ASSET_FUDGE_FACTOR  // degree's lon/lat, shows ILS beams even if ILS outside of map window
+
+namespace {
+
+struct NavaidBlobWriter {
+	vector<unsigned char> data;
+
+	template <typename T>
+	void WritePod(const T& value)
+	{
+		const unsigned char * begin = reinterpret_cast<const unsigned char *>(&value);
+		data.insert(data.end(), begin, begin + sizeof(T));
+	}
+};
+
+struct NavaidBlobReader {
+	const unsigned char * cur;
+	const unsigned char * end;
+
+	NavaidBlobReader(const vector<unsigned char>& payload) : cur(payload.data()), end(payload.data() + payload.size()) {}
+
+	template <typename T>
+	bool ReadPod(T& value)
+	{
+		if (static_cast<size_t>(end - cur) < sizeof(T))
+			return false;
+		memcpy(&value, cur, sizeof(T));
+		cur += sizeof(T);
+		return true;
+	}
+
+	bool Done() const
+	{
+		return cur == end;
+	}
+};
+
+static void WriteString(NavaidBlobWriter& writer, const string& value)
+{
+	unsigned int len = static_cast<unsigned int>(value.size());
+	writer.WritePod(len);
+	if (len)
+	{
+		const unsigned char * begin = reinterpret_cast<const unsigned char *>(value.data());
+		writer.data.insert(writer.data.end(), begin, begin + len);
+	}
+}
+
+static bool ReadString(NavaidBlobReader& reader, string& value)
+{
+	unsigned int len = 0;
+	if (!reader.ReadPod(len))
+		return false;
+	if (static_cast<size_t>(reader.end - reader.cur) < len)
+		return false;
+	value.assign(reinterpret_cast<const char *>(reader.cur), reinterpret_cast<const char *>(reader.cur + len));
+	reader.cur += len;
+	return true;
+}
+
+static void WritePoint2(NavaidBlobWriter& writer, const Point2& point)
+{
+	const double x = point.x();
+	const double y = point.y();
+	writer.WritePod(x);
+	writer.WritePod(y);
+}
+
+static bool ReadPoint2(NavaidBlobReader& reader, Point2& point)
+{
+	double x = 0.0;
+	double y = 0.0;
+	if (!reader.ReadPod(x) || !reader.ReadPod(y))
+		return false;
+	point = Point2(x, y);
+	return true;
+}
+
+static vector<unsigned char> SerializeNavaids(const vector<navaid_t>& navaids)
+{
+	NavaidBlobWriter writer;
+	const unsigned int count = static_cast<unsigned int>(navaids.size());
+	writer.WritePod(count);
+	for (const auto& aid : navaids)
+	{
+		writer.WritePod(aid.type);
+		WritePoint2(writer, aid.lonlat);
+		writer.WritePod(aid.heading);
+		WriteString(writer, aid.name);
+		WriteString(writer, aid.icao);
+		writer.WritePod(aid.freq);
+		WriteString(writer, aid.rwy);
+		const unsigned int shape_count = static_cast<unsigned int>(aid.shape.size());
+		writer.WritePod(shape_count);
+		for (const auto& polygon : aid.shape)
+		{
+			const unsigned int point_count = static_cast<unsigned int>(polygon.size());
+			writer.WritePod(point_count);
+			for (const auto& point : polygon)
+				WritePoint2(writer, point);
+		}
+	}
+	return writer.data;
+}
+
+static bool DeserializeNavaids(const vector<unsigned char>& payload, vector<navaid_t>& out_navaids)
+{
+	NavaidBlobReader reader(payload);
+	unsigned int count = 0;
+	if (!reader.ReadPod(count))
+		return false;
+
+	vector<navaid_t> decoded;
+	decoded.resize(count);
+	for (unsigned int i = 0; i < count; ++i)
+	{
+		navaid_t& aid = decoded[i];
+		if (!reader.ReadPod(aid.type) ||
+			!ReadPoint2(reader, aid.lonlat) ||
+			!reader.ReadPod(aid.heading) ||
+			!ReadString(reader, aid.name) ||
+			!ReadString(reader, aid.icao) ||
+			!reader.ReadPod(aid.freq) ||
+			!ReadString(reader, aid.rwy))
+		{
+			return false;
+		}
+
+		unsigned int shape_count = 0;
+		if (!reader.ReadPod(shape_count))
+			return false;
+		aid.shape.resize(shape_count);
+		for (unsigned int poly_index = 0; poly_index < shape_count; ++poly_index)
+		{
+			unsigned int point_count = 0;
+			if (!reader.ReadPod(point_count))
+				return false;
+			Polygon2 polygon(static_cast<int>(point_count));
+			for (unsigned int point_index = 0; point_index < point_count; ++point_index)
+			{
+				if (!ReadPoint2(reader, polygon[point_index]))
+					return false;
+			}
+			aid.shape[poly_index] = polygon;
+		}
+	}
+
+	if (!reader.Done())
+		return false;
+
+	out_navaids.swap(decoded);
+	return true;
+}
+
+static void AppendFileFingerprint(const char * label, const string& path, string& io_signature)
+{
+	io_signature += label;
+	io_signature += "=";
+	if (!path.empty())
+	{
+		struct stat meta_data = { 0 };
+		if (FILE_get_file_meta_data(path, meta_data) == 0)
+		{
+			io_signature += path;
+			io_signature += "|";
+			io_signature += std::to_string(static_cast<long long>(meta_data.st_size));
+			io_signature += "|";
+			io_signature += std::to_string(static_cast<long long>(meta_data.st_mtime));
+		}
+		else
+		{
+			io_signature += "stat_failed:";
+			io_signature += path;
+		}
+	}
+	else
+	{
+		io_signature += "missing";
+	}
+	io_signature += "\n";
+}
+
+static string FirstExistingPath(const vector<string>& candidates)
+{
+	for (const auto& candidate : candidates)
+	{
+		if (FILE_exists(candidate.c_str()))
+			return candidate;
+	}
+	return string();
+}
+
+static string BuildNavaidSourceSignature(const string& resourcePath)
+{
+	string signature("xplane_root=");
+	signature += resourcePath;
+	signature += "\n";
+
+	const string default_navaids = resourcePath + DIR_STR "Resources" DIR_STR "default data" DIR_STR "earth_nav.dat";
+	const string global_navaids = FirstExistingPath({
+		resourcePath + DIR_STR "Global Scenery" DIR_STR "Global Airports" DIR_STR "Earth nav data" DIR_STR "earth_nav.dat",
+		resourcePath + DIR_STR "Custom Scenery" DIR_STR "Global Airports" DIR_STR "Earth nav data" DIR_STR "earth_nav.dat"
+	});
+	const string atc_data = FirstExistingPath({
+		resourcePath + DIR_STR "Resources" DIR_STR "default scenery" DIR_STR "default atc dat" DIR_STR "Earth nav data" DIR_STR "atc.dat",
+		resourcePath + DIR_STR "Resources" DIR_STR "default scenery" DIR_STR "default atc" DIR_STR "Earth nav data" DIR_STR "atc.dat",
+		resourcePath + DIR_STR "Resources" DIR_STR "default scenery" DIR_STR "1200 atc data" DIR_STR "Earth nav data" DIR_STR "atc.dat"
+	});
+
+	AppendFileFingerprint("default_nav", default_navaids, signature);
+	AppendFileFingerprint("global_nav", global_navaids, signature);
+	AppendFileFingerprint("atc", atc_data, signature);
+
+#if SHOW_APTS_FROM_APTDAT
+	const string default_apts = resourcePath + DIR_STR "Resources" DIR_STR "default scenery" DIR_STR "default apt dat" DIR_STR "Earth nav data" DIR_STR "apt.dat";
+	const string global_apts = FirstExistingPath({
+		resourcePath + DIR_STR "Global Scenery" DIR_STR "Global Airports" DIR_STR "Earth nav data" DIR_STR "apt.dat",
+		resourcePath + DIR_STR "Custom Scenery" DIR_STR "Global Airports" DIR_STR "Earth nav data" DIR_STR "apt.dat"
+	});
+	AppendFileFingerprint("default_apt", default_apts, signature);
+	AppendFileFingerprint("global_apt", global_apts, signature);
+#endif
+
+	return signature;
+}
+
+}
 
 #if COMPARE_GW_TO_APTDAT
 
@@ -488,6 +719,16 @@ void WED_NavaidLayer::LoadNavaids(void)
 // ToDo: move this into PackageMgr, so its updated when XPlaneFolder changes and re-used when another scenery is opened
 	string resourcePath;
 	gPackageMgr->GetXPlaneFolder(resourcePath);
+	const string navaid_signature = BuildNavaidSourceSignature(resourcePath);
+
+	vector<unsigned char> cached_payload;
+	vector<navaid_t> decoded_navaids;
+	if (WED_ResourceCache::Get().LoadNavaidIndex(navaid_signature, cached_payload) &&
+		DeserializeNavaids(cached_payload, decoded_navaids))
+	{
+		mNavaids.assign(std::move(decoded_navaids));
+		return;
+	}
 
 	// deliberately ignoring any Custom Data/earth_424.dat or Custom Data/earth_nav.dat files that a user may have ... to avoid confusion
 	string defaultNavaids  = resourcePath + DIR_STR "Resources" DIR_STR "default data" DIR_STR "earth_nav.dat";
@@ -561,6 +802,7 @@ void WED_NavaidLayer::LoadNavaids(void)
 
 // Todo: speedup drawing by sorting mNavaids into longitude buckets, so the preview function only have to go through a smalller part of the overall list.
 //       although for now Navaid map drawing is under 1 msec on a 3.6 GHz CPU at all times == good enough
+	WED_ResourceCache::Get().StoreNavaidIndex(navaid_signature, SerializeNavaids(mNavaids.items()));
 }
 
 void		WED_NavaidLayer::DrawVisualization		(bool inCurrent, GUI_GraphState * g)

--- a/src/WEDMap/WED_NavaidLayer.h
+++ b/src/WEDMap/WED_NavaidLayer.h
@@ -56,8 +56,10 @@ private:
 					navaid_list();
 		auto		empty() const { return nav_list.empty(); }
 		auto		cbegin() const { return nav_list.cbegin(); }
+		const vector<navaid_t>& items() const { return nav_list; }
 		vector<navaid_t>::const_iterator cbegin(double longitude);   // starts iterating at first navaid >= longitude
 		auto		cend() const { return nav_list.cend(); }
+		void		assign(vector<navaid_t> aids) { nav_list.swap(aids); best_begin = -1; }
 		void		insert(const navaid_t& aid);
 		void		replace(vector<navaid_t>::const_iterator which, const navaid_t& aid);
 

--- a/src/WEDWindows/WED_DocumentWindow.cpp
+++ b/src/WEDWindows/WED_DocumentWindow.cpp
@@ -36,10 +36,12 @@
 #include "WED_MapPreviewWindow.h"
 #include "WED_PropertyHelper.h"
 #include "WED_PropertyPane.h"
+#include "WED_ResourceCache.h"
 #include "WED_Menus.h"
 #include "WED_Colors.h"
 #include "WED_Version.h"
 #include "WED_ToolUtils.h"
+#include "GUI_Prefs.h"
 #include "GUI_Splitter.h"
 #include "GUI_Menus.h"
 #include "GUI_TabPane.h"
@@ -345,6 +347,19 @@ int	WED_DocumentWindow::HandleCommand(int command)
 	//------------------------------------------//
 
 	switch(command) {
+	case wed_ToggleArtifactCache:
+		{
+			const bool enabled = !WED_ResourceCache::Get().Enabled();
+			GUI_SetPrefString("performance", "cache_artifact", enabled ? "1" : "0");
+			WED_ResourceCache::Get().SetEnabled(enabled);
+		}
+		return 1;
+	case wed_ClearArtifactCache:
+		if (WED_ResourceCache::Get().Clear())
+			DoUserAlert("Artifact cache cleared.");
+		else
+			DoUserAlert("Could not clear artifact cache.");
+		return 1;
 	case wed_RestorePanes:
 		{
 			int zw[2];
@@ -538,6 +553,8 @@ int	WED_DocumentWindow::CanHandleCommand(int command, string& ioName, int& ioChe
 	//------------------------------------------//
 
 	switch(command) {
+	case wed_ToggleArtifactCache:	ioCheck = WED_ResourceCache::Get().Enabled() ? 1 : 0; return 1;
+	case wed_ClearArtifactCache:	return 1;
 	case wed_autoOpenLibPane:
 	case wed_autoOpenPropPane:
 	case wed_autoClosePane:

--- a/src/WEDWindows/WED_Menus.cpp
+++ b/src/WEDWindows/WED_Menus.cpp
@@ -255,6 +255,12 @@ static const GUI_MenuItem_t kAirportMenu[] = {
 {	NULL,						0,		0,										0, 0,				}
 };
 
+static const GUI_MenuItem_t kPerformanceMenu[] = {
+{	"&Cache Artifact",			0,		0,										0,	wed_ToggleArtifactCache	},
+{	"Clear Artifact Cache",		0,		0,										0,	wed_ClearArtifactCache	},
+{	NULL,						0,		0,										0,	0					}
+};
+
 // end-begin?  YES!  Since begin is before the beginnined and end is AFTER the end this gives us ONE extra slot.
 // We NEED that slot to be the null terminator for the menu list.
 static GUI_MenuItem_t kAddMetaDataMenu[wed_AddMetaDataEnd-wed_AddMetaDataBegin] = { 0 };
@@ -358,6 +364,8 @@ void WED_MakeMenus(GUI_Application * inApp)
 	GUI_Menu	airport_add_meta_data_menu = inApp->CreateMenu(
 		"Add &Meta Data", kAddMetaDataMenu, airport_menu, 6);//This hardcoded 6 is a reference to
 															 //kAirportMenu[6]
+	GUI_Menu	performance_menu = inApp->CreateMenu(
+		"&Performance", kPerformanceMenu, inApp->GetMenuBar(), 0);
 	GUI_Menu	help_menu = inApp->CreateMenu(
 		"&Help", kHelpMenu, inApp->GetMenuBar(), 0);
 }

--- a/src/WEDWindows/WED_Menus.h
+++ b/src/WEDWindows/WED_Menus.h
@@ -191,6 +191,9 @@ enum {
 	wed_autoOpenLibPane,
 	wed_autoOpenPropPane,
 	wed_autoClosePane,
+	// Performance Menu
+	wed_ToggleArtifactCache,
+	wed_ClearArtifactCache,
 	// Help Menu
 	wed_HelpManual,
 	wed_HelpScenery,

--- a/src/WEDWindows/WED_StartWindow.cpp
+++ b/src/WEDWindows/WED_StartWindow.cpp
@@ -40,6 +40,7 @@
 #include "WED_UIDefs.h"
 #include "WED_Document.h"
 #include "WED_DocumentWindow.h"
+#include "WED_ResourceCache.h"
 #include "WED_Version.h"
 #include "GUI_Prefs.h"
 #include "GUI_Application.h"
@@ -330,7 +331,20 @@ int			WED_StartWindow::HandleCommand(int command)
 {
 	char buf[1024];
 
-	switch(command) {
+switch(command) {
+	case wed_ToggleArtifactCache:
+		{
+			const bool enabled = !WED_ResourceCache::Get().Enabled();
+			GUI_SetPrefString("performance", "cache_artifact", enabled ? "1" : "0");
+			WED_ResourceCache::Get().SetEnabled(enabled);
+		}
+		return 1;
+	case wed_ClearArtifactCache:
+		if (WED_ResourceCache::Get().Clear())
+			DoUserAlert("Artifact cache cleared.");
+		else
+			DoUserAlert("Could not clear artifact cache.");
+		return 1;
 	case wed_ChangeSystem:
 		if (GetFilePathFromUser(getFile_PickFolder, "Please select your X-Plane folder", "Select", FILE_DIALOG_PICK_XSYSTEM, buf, sizeof(buf) ))
 		{
@@ -388,7 +402,9 @@ int			WED_StartWindow::HandleCommand(int command)
 
 int			WED_StartWindow::CanHandleCommand(int command, string& ioName, int& ioCheck)
 {
-	switch(command) {
+switch(command) {
+	case wed_ToggleArtifactCache:	ioCheck = WED_ResourceCache::Get().Enabled() ? 1 : 0; return 1;
+	case wed_ClearArtifactCache:	return 1;
 	case wed_NewPackage:	return gPackageMgr->HasSystemFolder();
 	case wed_ChangeSystem:	return 1;
 	case wed_OpenPackage:	return gPackageMgr->HasSystemFolder() && mPackageList->HasSelection();


### PR DESCRIPTION
﻿## Why

Opening very large airports can spend a long time in first-screen setup because WED repeatedly re-parses OBJ/AGP resources, re-decodes textures, and reparses Navaid reference data even when those inputs have not changed.

In our local testing on a representative large airport package (ZGSZ), the source-backed path was a 20+ wating process everytime. The goal of this PR is to keep the existing synchronous loading model, but avoid doing the same expensive work again on warm reopens.

## How

This PR adds a bounded on-disk artifact cache for WED resource hot paths.

What is cached:
- OBJ geometry hot-path artifacts, so warm hits do not need to reparse `.obj` text.
- Prepared texture artifacts, so warm hits do not need to re-decode source images.
- Compressed texture artifacts, so warm hits can use `glCompressedTexImage2D` instead of paying driver-side on-the-fly compression again.
- Navaid index artifacts, so warm hits do not need to reparse `earth_nav.dat` / `atc.dat` / `apt.dat` when the Navaid overlay is visible.

Storage model:
- SQLite index
- segment-based pack storage
- bounded cache size with simple whole-segment eviction
- current implementation uses a 16 GiB cap and 1 GiB segments

Important behavior notes:
- This keeps the original synchronous load model. There is no async resource loading in this PR.
- Cache miss behavior is unchanged: on miss, WED still falls back to the existing source-backed load path.
- Cache entries are keyed from source inputs and internal schema/layout versions, so changed inputs naturally miss and rebuild.

## User Interface

This PR adds a new top-level `Performance` menu with:
- `Cache Artifact` (persistent toggle, default on)
- `Clear Artifact Cache`

So users who do not want the cache can disable it, and users can explicitly clear the on-disk artifacts.

## Measurements

Representative local measurements on ZGSZ:
- sync prepared-texture hot path before compressed texture artifact: first draw about `6.3 s`
- fully warm compressed-artifact hot path after this PR: first draw about `1.7-1.8 s`
- when the Navaid overlay is visible, Navaid first-use parse dropped from about `0.49 s` to about `0.009 s` on warm hit

In short: this PR is aimed at large-airport reopen performance, and in our local measurements it moved the hot first-screen path from 20+ seconds down to about two seconds without changing WED's synchronous loading semantics.

## Validation

Local validation performed on Windows:
- Release build succeeds
- cache clear and rebuild succeeds
- warm reopen uses cache artifacts correctly
- cache cap / menu controls work
