### PR TITLE
Notarize with an App Store Connect API key

### DIFF
--- a/.github/workflows/build_wed.yml
+++ b/.github/workflows/build_wed.yml
@@ -34,9 +34,11 @@ jobs:
   build-mac:
     runs-on: macos-12
     env:
-      APPLE_ID: ${{ secrets.APPLE_ID }}
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      # Notarization auths with an App Store Connect API key (see scripts/notarization.sh).
+      # Unlike an Apple ID + app-specific password, the key survives password rotations.
+      APPLE_NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
+      APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+      APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@main

--- a/.github/workflows/build_xptools.yml
+++ b/.github/workflows/build_xptools.yml
@@ -37,9 +37,13 @@ jobs:
   build-mac:
     runs-on: macos-11
     env:
-      APPLE_ID: ${{ secrets.APPLE_ID }}
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      # Notarization auths with an App Store Connect API key (see scripts/notarization.sh).
+      # Unlike an Apple ID + app-specific password, the key survives password rotations.
+      # (The Notarize step below is currently commented out, but keep the env current
+      # so re-enabling it works.)
+      APPLE_NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
+      APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+      APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@main

--- a/scripts/notarization.sh
+++ b/scripts/notarization.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
-# 
-# The running machine must have Apple ID credentials pre-registered in the key chain under
-# the KC item AC_PASSWORD
+#
+# Notarizes (and optionally staples) a mac binary.
+#
+# Credentials, in order of preference:
+#   1. App Store Connect API key via env: APPLE_NOTARY_KEY (the .p8 contents),
+#      APPLE_NOTARY_KEY_ID, APPLE_NOTARY_ISSUER_ID. This is what CI uses --
+#      API keys survive Apple ID password rotations, app-specific passwords don't.
+#   2. A keychain profile named AC_PASSWORD (for manual runs on a dev Mac,
+#      set up once with `xcrun notarytool store-credentials "AC_PASSWORD" ...`).
 
 # Note: this only works on macOS, since it relies on Apple tools.
 
@@ -24,18 +30,23 @@ staple=$3
 rm "$zip_path"
 zip -rq --symlink "$zip_path" "$app_path"
 
-if [ -z $APP_SPECIFIC_PASSWORD ]; then
-    echo "APP_SPECIFIC_PASSWORD or APPLE_TEAM_ID is not set. Using Keychain for credentials"
+if [ -n "$APPLE_NOTARY_KEY_ID" ]; then
+    echo "Using App Store Connect API key for credentials"
+    key_file="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/notary_key.p8"
+    printf '%s' "$APPLE_NOTARY_KEY" > "$key_file"
     xcrun notarytool submit "$zip_path" \
-                   --keychain-profile "AC_PASSWORD" \
+                   --key "$key_file" \
+                   --key-id "$APPLE_NOTARY_KEY_ID" \
+                   --issuer "$APPLE_NOTARY_ISSUER_ID" \
                    --wait \
                    --timeout 10m
+    result=$?
+    rm -f "$key_file"
+    [ $result -eq 0 ] || exit $result
 else
-    echo "Using username, password and team-id for credentials"
+    echo "APPLE_NOTARY_KEY_ID is not set. Using Keychain for credentials"
     xcrun notarytool submit "$zip_path" \
-                   --apple-id "${APPLE_ID}" \
-                   --team-id "${APPLE_TEAM_ID}" \
-                   --password "${APP_SPECIFIC_PASSWORD}" \
+                   --keychain-profile "AC_PASSWORD" \
                    --wait \
                    --timeout 10m
 fi


### PR DESCRIPTION
Companion to X-Plane/XLua#32: switches notarization.sh from Apple ID + app-specific password auth to an App Store Connect API key (APPLE_NOTARY_KEY / APPLE_NOTARY_KEY_ID / APPLE_NOTARY_ISSUER_ID org secrets), keeping the AC_PASSWORD keychain-profile path for manual runs on a dev Mac. Both mac workflows pass the new env trio.

Note for the release flow: build WED runs from wed_2*_release branches, which carry their own workflow copy, so this needs merging onto the active release branch before the next WED release build.